### PR TITLE
impact and population constructors

### DIFF
--- a/agrifoodpy/food/food_supply.py
+++ b/agrifoodpy/food/food_supply.py
@@ -26,35 +26,105 @@ FAOSTAT_elements = ['production',
                     'food',
                     ]
 
-def FoodSupply(items, years, quantities, regions=None, elements=None):
+def FoodSupply(items, years, quantities, regions=None, elements=None, long_format=True):
+    """ Food Supply style dataset constructor
+     
+    Parameters
+    ----------
+    items : (ni,) array_like
+        The Item identifying ID or strings for which coordinates will be
+        created.
+    years : years : (ny,) array_like
+        The year values for which coordinates will be created.
+    quantities : ([ne], ni, ny, [nr]) ndarray
+        Array containing the food quantity for each combination of `Item`,
+        `Year` and, optionally `Region`.
+    regions : (nr,) array_like, optional
+        The region identifying ID or strings for which coordinates will be
+        created.
+    long_format : bool
+        Boolean flag to interpret data in long or wide format
+    elemements : (ne,) array_like, optional
+        Array with element name strings. If `elements` is provided, a dataset
+        is created for each element in `elements` with the quantities being each
+        of the sub-arrays indexed by the first coordinate of the input array.
 
-    _years = np.unique(years)
+    Returns
+    -------
+    data : xarray.Dataset
+        Food Supply dataset containing the food quantity for each `Item`, `Year`
+        and `Region` with one dataarray per element in `elements`.
+    """
+
+    # if the input has a single element, proceed with long format
+    if np.isscalar(quantities):
+        long_format = True
+
+    quantities = np.array(quantities)
+
+    # Identify unique values in coordinates
     _items = np.unique(items)
+    _years = np.unique(years)
+    coords = {"Item" : _items,
+              "Year" : _years,} 
 
-    size = (len(_years), len(_items))
+    # find positions in output array to organize data
+    ii = [np.searchsorted(_items, items), np.searchsorted(_years, years)]
+    size = (len(_items), len(_years))
 
-    ii = [np.searchsorted(_years, years), np.searchsorted(_items, items)]
-
-    coords = {"Year" : _years,
-              "Item" : _items}
-
+    # If regions and are provided, add the coordinate information 
     if regions is not None:
         _regions = np.unique(regions)
         ii.append(np.searchsorted(_regions, regions))
         size = size + (len(_regions),)
         coords["Region"] = _regions
 
-    if elements is not None:
-        _elements = np.unique(elements)
-        ii.append(np.searchsorted(_elements, elements))
-        coords["Element"] = _elements
-        size = size + (len(_elements),)
+    # Create empty dataset
+    data = xr.Dataset(coords = coords)
 
-    values = np.zeros(size)*np.nan
+    if long_format:
+        # dataset, quantities
+        ndims = 2
+    else:
+        # dataset, coords
+        ndims = len(coords)+1
+    
+    # make sure the long format has the right number of dimensions
+    while len(quantities.shape) < ndims:
+        quantities = np.expand_dims(quantities, axis=0)
 
-    values[tuple(ii)] = quantities
+    # If no elements names are given, then create generic ones,
+    # one for each dataset
+    if elements is None:
+        elements = [f"Quantity {id}" for id in range(quantities.shape[0])]
 
-    data = xr.Dataset(data_vars = dict(value=(coords.keys(), values)), coords = coords)
+    # Else, if a single string is given, transform to list. If doesn't match
+    # the number of datasets created above, xarray will return an error.
+    elif isinstance(elements, str):
+        elements = [elements]
+
+    if long_format:
+        # Create a datasets, one at a time
+        for ie, element in enumerate(elements):
+            values = np.zeros(size)*np.nan
+            values[tuple(ii)] = quantities[ie]
+            data[element] = (coords, values)
+
+    else:
+        quantities = quantities[:, ii[0]]
+        if len(quantities.shape) < ndims:
+            quantities = np.expand_dims(quantities, axis=0)
+
+        quantities = quantities[:, :, ii[1]]
+        if len(quantities.shape) < ndims:
+            quantities = np.expand_dims(quantities, axis=0)
+
+        if regions is not None:
+            quantities = quantities[..., ii[2]]
+        # Create a datasets, one at a time
+        for ie, element in enumerate(elements):
+            values = quantities[ie]
+            data[element] = (coords, values)
 
     return data
 

--- a/agrifoodpy/impact/impact.py
+++ b/agrifoodpy/impact/impact.py
@@ -5,28 +5,83 @@ import os
 data_dir = os.path.join(os.path.dirname(__file__), 'data/' )
 available = ['PN18', 'PN18_FAOSTAT']
 
-def impacts(items, impacts, quantities, regions=None):
-    _impacts = np.unique(impacts)
+def impacts(items, regions, quantities, datasets=None, long_format=True):
+    """Impact style dataset constructor
+
+    Parameters
+    ----------
+    items : (ny,) array_like
+        The Item identifying ID or strings for which coordinates will be
+        created.
+    regions : (nr,) array_like, optional
+        The region identifying ID or strings for which coordinates will be
+        created.
+    quantities : (ny, nr) ndarray
+        Array containing the quantities for each combination of `Item` and
+        `Region`.
+    datasets : (nd,) array_like, optional
+        Array with model name strings
+    long_format : bool
+        Boolean flag to interpret data in long or wide format
+
+    Returns
+    -------
+    data : xarray.Dataset
+        Impact dataset containing the impact for each `Item` and
+        `Region` with one dataarray per element in `dataset`.
+    """
+
+    quantities = np.array(quantities)
+
+    # Identify unique values in coordinates
     _items = np.unique(items)
+    _regions = np.unique(regions)
 
-    size = (len(_impacts), len(_items))
+    coords = {"Item" : _items,
+              "Region" : _regions}
 
-    ii = [np.searchsorted(_impacts, impacts), np.searchsorted(_items, items)]
+    # find positions in output array to organize data
+    ii = [np.searchsorted(_items, items), np.searchsorted(_regions, regions)]
+    size = (len(_items), len(_regions))
 
-    coords = {"Year" : _impacts,
-              "Item" : _items}
+    # Create empty dataset
+    data = xr.Dataset(coords = coords)
 
-    if regions is not None:
-        _regions = np.unique(regions)
-        ii.append(np.searchsorted(_regions, regions))
-        size = size + (len(_regions),)
-        coords["Region"] = _regions
+    if long_format:
+        ndims = 2
+    else:
+        ndims = 3
 
-    values = np.zeros(size)*np.nan
+    # make sure the long format has two dimensions
+    # One along items and regions, one along datasets
+    while len(quantities.shape) < ndims:
+        quantities = np.expand_dims(quantities, axis=0)
 
-    values[tuple(ii)] = quantities
+    # If no dataset names are given, then create generic ones, one for each
+    # dataset
+    if datasets is None:
+        datasets = [f"Impact {id}" for id in range(quantities.shape[0])]
 
-    data = xr.Dataset(data_vars = dict(value=(coords.keys(), values)), coords = coords)
+    # Else, if a single string is given, transform to list. If doesn't match
+    # the number of datasets created above, this will spit a list later.
+    elif isinstance(datasets, str):
+        datasets = [datasets]
+
+    if long_format:
+        # Create a datasets, one at a time
+        for id, dataset in enumerate(datasets):
+            values = np.zeros(size)*np.nan
+            values[tuple(ii)] = quantities[id]
+            data[dataset] = (coords, values)
+
+    else:
+        quantities = quantities[:, ii[0], :]
+        quantities = quantities[:, :, ii[1]]
+
+        # Create a datasets, one at a time
+        for id, dataset in enumerate(datasets):
+            values = quantities[id]
+            data[dataset] = (coords, values)
 
     return data
 

--- a/agrifoodpy/impact/impact.py
+++ b/agrifoodpy/impact/impact.py
@@ -31,6 +31,10 @@ def impacts(items, regions, quantities, datasets=None, long_format=True):
         `Region` with one dataarray per element in `dataset`.
     """
 
+    # if the input has a single element, proceed with long format
+    if np.isscalar(quantities):
+        long_format = True
+
     quantities = np.array(quantities)
 
     # Identify unique values in coordinates
@@ -75,8 +79,8 @@ def impacts(items, regions, quantities, datasets=None, long_format=True):
             data[dataset] = (coords, values)
 
     else:
-        quantities = quantities[:, ii[0], :]
-        quantities = quantities[:, :, ii[1]]
+        quantities = quantities[:, ii[0]]
+        quantities = quantities[..., ii[1]]
 
         # Create a datasets, one at a time
         for id, dataset in enumerate(datasets):

--- a/agrifoodpy/population/population_data.py
+++ b/agrifoodpy/population/population_data.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pandas as pd
 import os
 import xarray as xr
 
@@ -7,6 +6,84 @@ from ..utils.list_tools import tolist
 
 data_dir = os.path.join(os.path.dirname(__file__), 'data/' )
 available = ['UN']
+
+def population(years, regions, quantities, datasets=None, long_format=True):
+    """Population style dataset constructor
+
+    Parameters
+    ----------
+    years : (ny,) array_like
+        The year values for which coordinates will be created.
+    regions : (nr,) array_like, optional
+        The region identifying ID or strings for which coordinates will be
+        created.
+    quantities : (ny, nr) ndarray
+        Array containing the population for each combination of `Year` and
+        `Region`.
+    datasets : (nd,) array_like, optional
+        Array with model name strings
+    long_format : bool
+        Boolean flag to interpret data in long or wide format
+
+    Returns
+    -------
+    data : xarray.Dataset
+        Population dataset containing the population for each `Year` and
+        `Region` with one dataarray per element in `dataset`.
+    """
+
+    quantities = np.array(quantities)
+
+    # Identify unique values in coordinates
+    _years = np.unique(years)
+    _regions = np.unique(regions)
+    coords = {"Year" : _years,
+              "Region" : _regions}
+
+    # find positions in output array to organize data
+    ii = [np.searchsorted(_years, years), np.searchsorted(_regions, regions)]
+    size = (len(_years), len(_regions))
+
+    # Create empty dataset
+    data = xr.Dataset(coords = coords)
+
+    if long_format:
+        ndims = 2
+    else:
+        ndims = 3
+
+    # make sure the long format has two dimensions
+    # One along years and regions, one along datasets
+    while len(quantities.shape) < ndims:
+        quantities = np.expand_dims(quantities, axis=0)
+
+    # If no dataset names are given, then create generic ones, one for each
+    # dataset
+    if datasets is None:
+        datasets = [f"Population {id}" for id in range(quantities.shape[0])]
+
+    # Else, if a single string is given, transform to list. If doesn't match
+    # the number of datasets created above, this will spit a list later.
+    elif isinstance(datasets, str):
+        datasets = [datasets]
+
+    if long_format:
+        # Create a datasets, one at a time
+        for id, dataset in enumerate(datasets):
+            values = np.zeros(size)*np.nan
+            values[tuple(ii)] = quantities[id]
+            data[dataset] = (coords, values)
+
+    else:
+        quantities = quantities[:, ii[0], :]
+        quantities = quantities[:, :, ii[1]]
+
+        # Create a datasets, one at a time
+        for id, dataset in enumerate(datasets):
+            values = quantities[id]
+            data[dataset] = (coords, values)
+
+    return data
 
 def __getattr__(name):
     if name not in available:

--- a/agrifoodpy/population/population_data.py
+++ b/agrifoodpy/population/population_data.py
@@ -17,11 +17,13 @@ def population(years, regions, quantities, datasets=None, long_format=True):
     regions : (nr,) array_like, optional
         The region identifying ID or strings for which coordinates will be
         created.
-    quantities : (ny, nr) ndarray
+    quantities : ([nd], ny, nr) ndarray
         Array containing the population for each combination of `Year` and
         `Region`.
     datasets : (nd,) array_like, optional
-        Array with model name strings
+        Array with model name strings. If provided, a dataset is created
+        for each element in `datasets` with the quantities being each of the
+        sub-arrays indexed by the last coordinate of the input array.
     long_format : bool
         Boolean flag to interpret data in long or wide format
 
@@ -31,6 +33,10 @@ def population(years, regions, quantities, datasets=None, long_format=True):
         Population dataset containing the population for each `Year` and
         `Region` with one dataarray per element in `dataset`.
     """
+
+    # if the input has a single element, proceed with long format
+    if np.isscalar(quantities):
+        long_format = True
 
     quantities = np.array(quantities)
 
@@ -48,12 +54,13 @@ def population(years, regions, quantities, datasets=None, long_format=True):
     data = xr.Dataset(coords = coords)
 
     if long_format:
+        # dataset, quantities
         ndims = 2
     else:
+        # dataset, year, region
         ndims = 3
 
-    # make sure the long format has two dimensions
-    # One along years and regions, one along datasets
+    # make sure the long format has the right number of dimensions
     while len(quantities.shape) < ndims:
         quantities = np.expand_dims(quantities, axis=0)
 
@@ -63,7 +70,7 @@ def population(years, regions, quantities, datasets=None, long_format=True):
         datasets = [f"Population {id}" for id in range(quantities.shape[0])]
 
     # Else, if a single string is given, transform to list. If doesn't match
-    # the number of datasets created above, this will spit a list later.
+    # the number of datasets created above, xarray will return an error.
     elif isinstance(datasets, str):
         datasets = [datasets]
 
@@ -75,9 +82,13 @@ def population(years, regions, quantities, datasets=None, long_format=True):
             data[dataset] = (coords, values)
 
     else:
-        quantities = quantities[:, ii[0], :]
-        quantities = quantities[:, :, ii[1]]
+        quantities = quantities[:, ii[0]]
+        if len(quantities.shape) < ndims:
+            quantities = np.expand_dims(quantities, axis=0)
 
+        quantities = quantities[..., ii[1]]
+        if len(quantities.shape) < ndims:
+            quantities = np.expand_dims(quantities, axis=0)
         # Create a datasets, one at a time
         for id, dataset in enumerate(datasets):
             values = quantities[id]


### PR DESCRIPTION
Added constructor functions for the Impact and Population modules.
They return xarrays with the same structure as the ones in the distributed datasets.

Both receive a matrix in either long format:

| item | region | quantity |
|--------|-----------|--------------|
| item i | region a | q_ia |
| item j | region a| q_ja |
| item i| region b| q_ib |
| ...| ...| ... |

or wide format

| - | item i | item j | ...|
|--------|-----------|--------------|---|
|region a|q_ia|q_ja|...|
|region b |q_ib|q_jb|...|
|region c| q_ic|q_jc|...|
| ...|...|...|...|

A boolean flag must be set to identify which format the input data is.
This fixes #30, although some work has to be done with the foodsupply constructor as well in order to make it consistent with the data examples and these constructors here. I'll set this PR as a draft for now
