### PR TITLE
Fixes to modules, plotting, base class, tests

### DIFF
--- a/agrifoodpy/food/food.py
+++ b/agrifoodpy/food/food.py
@@ -368,11 +368,12 @@ class FoodBalanceSheet(XarrayAccessorBase):
         print_labels = True
         if labels is None:
             # empty label placeholder and no-label flag
-            labels = np.empty(len(fbs[show].values))
+            labels = np.empty(len(fbs[show].values), dtype=str)
             print_labels = False
 
         elif np.all(labels == "show"):
-            labels = fbs[show].values
+            labels = [str(val) for val in fbs[show].values]
+
 
         # Plot non inverted elements first
         cumul = 0
@@ -429,7 +430,7 @@ class FoodBalanceSheet(XarrayAccessorBase):
 @xr.register_dataarray_accessor("fes")
 class FoodElementSheet(XarrayAccessorBase):
         
-    def plot_years(self, show="Item", ax=None, colors=None, labels=None,
+    def plot_years(self, show="Year", ax=None, colors=None, labels=None,
                    stack=True, **kwargs):
         """ Fill plot with quantities at each year value
 

--- a/agrifoodpy/food/model.py
+++ b/agrifoodpy/food/model.py
@@ -6,52 +6,51 @@ import numpy as np
 # from .food_supply import FoodBalanceSheet
 import warnings
 
-def balanced_scaling(fbs, element, items, scale, origin="imports",
-                     constant=True, fallback="exports", adoption="logistic",
-                     timescale=10, start_year=None):
-    """ Scale the consumption of selected items.
+def balanced_scaling(fbs, items, scale, element, year=None, adoption=None, 
+                     timescale=10, origin=None, constant=False,
+                     fallback=None):
+    """Scale items quantities across multiple elements in a FoodBalanceSheet
+    Dataset 
     
-    Scales consumption on a food balance sheet. The speed at which the adoption
-    takes place is defined by the timescale parameter which sets the shape of
-    the logistic function.
+    Scales selected item quantities on a food balance sheet and with the
+    posibility to keep the sum of selected elements constant.
+    Optionally, produce an Dataset with a sequence of quantities over the years
+    following a smooth scaling according to the selected functional form.
 
-    To accomodate for the required additional or reduced consumption, "imports",
-    "exports" or production can be adjusted to keep the food balance sheet
-    balanced. If the quantities on these DataArrays are not enough to provide
-    the required consumption, then the remaining is taken out of the "fallback"
-    DataArray.
-
-    The scaling is applied to the selected "items" list. If "constant" is set to
-    True, then the items not selected in the list are scaled multiplicatively to
-    ensure that the sum of the "food" DataArray remains constant.
+    The elements used to supply the modified quantities can be selected to keep
+    a balanced food balance sheet.
 
     Parameters
     ----------
     fbs : xarray.Dataset
-        Input food balance sheet Dataset
+        Input food balance sheet Dataset.
     items : list
-        List of items to scale in the food balance sheet
+        List of items to scale in the food balance sheet.
+    element : string
+        Name of the DataArray to scale.
     scale : float
-        Consumed food scaling parameter after full adoption 
-    timescale : int
-        Number of year the scaling takes to be applied completely
+        Scaling parameter after full adoption.
+    year : int, optional
+        Year of the Food Balance Sheet to use. If not set, the last year of the 
+        array is used
+    adoption : string, optional
+        Shape of the scaling adoption curve. "logistic" uses a logistic model
+        for a slow-fast-slow adoption. "linear" uses a constant slope adoption
+        during the the "timescale period"
+    timescale : int, optional
+        Timescale for the scaling to be applied completely.  If "year" +
+        "timescale" is greater than the last year in the array, it is extended
+        to accomodate the extra years.
     origin : string, optional
         Name of the DataArray which will be used to balance the food balance
-        sheets. Any change to the "food" DataArray will be reflected in this
+        sheets. Any change to the "element" DataArray will be reflected in this
         DataArray.
     constant : bool, optional
-        If set to True, the sum of "food" remains constant by scaling the non
+        If set to True, the sum of element remains constant by scaling the non
         selected items accordingly.
     fallback : string, optional
         Name of the DataArray used to provide the excess required to balance the
         food balance sheet in case the "origin" falls below zero.
-    adoption : string
-        Shape of the scaling adoption curve. "logistic" uses a logistic model
-        for a slow-fast-slow adoption. "linear" uses a constant slope adoption
-        during the the "timescale period"
-    start_year : int
-        Year at which the scaling start. "start_year" + "timescale" must be
-        greater or equal than the last year of the "Year" coordinate.
 
     Returns
     -------
@@ -64,14 +63,12 @@ def balanced_scaling(fbs, element, items, scale, origin="imports",
         items = [items]
 
     # Check for single item list fbs
-    input_item_list = fbs.Item.values.tolist()
+    input_item_list = fbs.Item.values
     if np.isscalar(input_item_list):
         input_item_list = [input_item_list]
         if constant:
-            warnings.warn("Constant set to true but input only has one item.")
+            warnings.warn("Constant set to true but input only has a single item.")
             constant = False
-    else:
-        sel = {"Item":items}
 
     # If no items are provided, we scale all of them.
     if items is None or np.sort(items) is np.sort(input_item_list):
@@ -80,52 +77,72 @@ def balanced_scaling(fbs, element, items, scale, origin="imports",
             warnings.warn("Cannot keep food constant when scaling all items.")
             constant = False
 
-    # Create a deep copy to modify and return
-    out = fbs.copy(deep=True)
+    # Define Dataarray to use as pivot
+    if "Year" in fbs.dims:
+        if year is None:
+            if np.isscalar(fbs.Year.values):
+                year = fbs.Year.values
+                fbs_toscale = fbs
+            else:
+                year = fbs.Year.values[-1]
+                fbs_toscale = fbs.isel(Year=-1)
+        else:
+            fbs_toscale = fbs.sel(Year=year)
 
-    # Scale items
-    years = fbs.Year.values
-    if start_year is None:
-        start_year = years[0]
-
-    if adoption == "linear":
-        from agrifoodpy.utils.scaling import linear_scale as scale_func
     else:
-        from agrifoodpy.utils.scaling import logistic_scale as scale_func
+        fbs_toscale = fbs
+        try:
+            year = fbs.Year.values
+        except AttributeError:
+            year=0
 
-    scale_arr = scale_func(years[0], start_year, start_year+timescale,
-                                 years[-1], c_init=1, c_end = scale)
+    # Define scale array based on year range
+    if adoption is not None:
+        if adoption == "linear":
+            from agrifoodpy.utils.scaling import linear_scale as scale_func
+        elif adoption == "logistic":
+            from agrifoodpy.utils.scaling import logistic_scale as scale_func
+        else:
+            raise ValueError("Adoption must be one of 'linear' or 'logistic'")
+        
+        scale_arr = scale_func(year, year, year+timescale-1, year+timescale-1,
+                               c_init=1, c_end = scale)
+        
+        fbs_toscale = fbs_toscale * xr.ones_like(scale_arr)
     
+    else:
+        scale_arr = scale
+
+    # Create a deep copy to modify and return
+    out = fbs_toscale.copy(deep=True)
     osplit = origin.split("-")[-1]
     
     out = out.fbs.scale_add(element, osplit, scale_arr, items, 
                             add = origin.startswith("-"))
     
-    delta = out[element] - fbs[element]
-    
-    
-    
+
     if constant:
-        # non selected items
-        non_sel_items = np.setdiff1d(fbs.Item.values, items)
-        non_sel_scale = (fbs.sel(Item=non_sel_items)["food"].sum(dim="Item") -
-                        delta.sum(dim="Item")) / \
-                        fbs.sel(Item=non_sel_items)["food"]
+
+        delta = out[element] - fbs_toscale[element]
+
+        # Scale non selected items
+        non_sel_items = np.setdiff1d(fbs_toscale.Item.values, items)
+        non_sel_scale = (fbs_toscale.sel(Item=non_sel_items)[element].sum(dim="Item") - delta.sum(dim="Item")) / fbs_toscale.sel(Item=non_sel_items)[element].sum(dim="Item")
+        
+        # Make sure inf and nan values are not scaled
+        non_sel_scale = non_sel_scale.where(np.isfinite(non_sel_scale)).fillna(1.0)
 
         if np.any(non_sel_scale < 0):
             warnings.warn("Additional consumption cannot be compensated by \
-                          reduction of non-selected items")
+                        reduction of non-selected items")
         
-        # add = not origin.startswith("-")
         out = out.fbs.scale_add(element, osplit, non_sel_scale,
                         non_sel_items, add = origin.startswith("-"))
 
-    
-
-    df = out[osplit].where(out[osplit] < 0).fillna(0)
-
-    out[fallback.split("-")[-1]] -= np.where(fallback.startswith("-"), 1, -1)*df
-
-    out[osplit] = out[osplit].where(out[osplit] > 0, 0)
+        # If fallback is defined, adjust to prevent negative values
+        if fallback is not None:
+            df = out[osplit].where(out[osplit] < 0).fillna(0)
+            out[fallback.split("-")[-1]] -= np.where(fallback.startswith("-"), 1, -1)*df
+            out[osplit] = out[osplit].where(out[osplit] > 0, 0)
 
     return out

--- a/agrifoodpy/food/tests/test_model.py
+++ b/agrifoodpy/food/tests/test_model.py
@@ -3,5 +3,6 @@ import xarray as xr
 
 import warnings
 
-def test_scale_consumption():
-    pass
+def test_balanced_scaling():
+    
+    from agrifoodpy.food.model import balanced_scaling

--- a/agrifoodpy/impact/impact.py
+++ b/agrifoodpy/impact/impact.py
@@ -3,9 +3,9 @@
 
 import numpy as np
 import xarray as xr
-import os
+from agrifoodpy.array_accessor import XarrayAccessorBase
 
-def impacts(items, regions, quantities, datasets=None, long_format=True):
+def impact(items, regions, quantities, datasets=None, long_format=True):
     """Impact style dataset constructor
 
     Parameters
@@ -90,7 +90,7 @@ def impacts(items, regions, quantities, datasets=None, long_format=True):
     return data
 
 @xr.register_dataset_accessor("impact")
-class Impact:
+class Impact(XarrayAccessorBase):
 
     def __init__(self, xarray_obj):
         self._validate(xarray_obj)
@@ -132,7 +132,8 @@ class Impact:
         # First column is the item code column
         in_items_mat = matching_matrix.columns[1:]
 
-        assert np.equal(in_items, in_items_mat).all() , "Input items do not match assignment matrix"
+        assert np.equal(in_items, in_items_mat).all() , \
+            "Input items do not match assignment matrix"
 
         # Again, we avoid first column
         mat = matching_matrix.iloc[:, 1:].fillna(0).to_numpy()

--- a/agrifoodpy/impact/tests/test_model.py
+++ b/agrifoodpy/impact/tests/test_model.py
@@ -1,0 +1,120 @@
+import numpy as np
+import xarray as xr
+
+def test_fbs_impacts():
+
+    from agrifoodpy.impact.model import fbs_impacts
+
+    # Basic test
+    items = ["Beef", "Apples"]
+    years = [2020, 2021]
+
+    fbs = xr.Dataset(
+        data_vars=dict(
+            imports=(["Year", "Item"], [[10, 20], [30, 40]]),
+            exports=(["Year", "Item"], [[5, 10], [15, 20]]),
+            production=(["Year", "Item"], [[50, 60], [70, 80]])
+            ),
+
+    coords=dict(Item=("Item", items), Year=("Year", years))
+    )
+
+    impact = xr.DataArray([100, 0.5], dims=("Item"), coords={"Item": items})
+
+    result = fbs_impacts(fbs, impact)
+
+    truth = xr.Dataset(
+        data_vars=dict(
+            imports=(["Year", "Item"], [[1000, 10], [3000, 20]]),
+            exports=(["Year", "Item"], [[500, 5], [1500, 10]]),
+            production=(["Year", "Item"], [[5000, 30], [7000, 40]])
+            ),
+        coords=dict(Item=("Item", items), Year=("Year", years))
+    )
+
+    assert result.equals(truth)
+
+    # Test with population
+    population = xr.DataArray(
+        data = [1.0e6, 1.1e6],
+        dims= ("Year"),
+        coords={"Year": years})
+
+    result = fbs_impacts(fbs, impact, population=population)
+
+    truth = xr.Dataset(
+        data_vars=dict(
+            imports=(["Year", "Item"], [[1e9, 1e7], [3.3e9, 2.2e7]]),
+            exports=(["Year", "Item"], [[5e8, 5e6], [1.65e9, 1.1e7]]),
+            production=(["Year", "Item"], [[5e9, 3e7], [7.7e9, 4.4e7]])
+            ),
+        coords=dict(Item=("Item", items),
+                    Year=("Year", years))
+        )
+        
+    assert result.equals(truth)
+
+    # Test summing over dimensions
+
+    sum_dims = ["Item"]
+
+    result = fbs_impacts(fbs, impact, sum_dims=sum_dims)
+
+    truth = xr.Dataset(
+        data_vars=dict(
+            imports=(["Year"], [1.01e3, 3.02e3]),
+            exports=(["Year"], [5.05e2, 1.51e3]),
+            production=(["Year"], [5.03e3, 7.04e3])
+            ),
+        coords=dict(Year=("Year", years))
+        )
+        
+    assert result.equals(truth)
+
+def test_fair_interface():
+
+    from agrifoodpy.impact.model import fair_co2_only
+
+    # Test with single emission
+
+    emissions = xr.DataArray(10, coords={"Year":2015})
+
+    T, C, F = fair_co2_only(emissions=emissions)
+
+    T_truth = xr.DataArray([0.0, 0.00133196], 
+                           coords={"timebounds":[2014.5, 2015.5]})
+    C_truth = xr.DataArray([278.3, 279.3534663],
+                           coords={"timebounds":[2014.5, 2015.5]})
+    F_truth = xr.DataArray([0.0, 0.02122413],
+                           coords={"timebounds":[2014.5, 2015.5]})
+
+    xr.testing.assert_allclose(T, T_truth)
+    xr.testing.assert_allclose(C, C_truth)
+    xr.testing.assert_allclose(F, F_truth)
+
+    # Test with multiple emission values
+
+    emissions = xr.DataArray(np.repeat(35, 10),
+                             coords={"Year":np.arange(2010,2020)})
+
+    T, C, F = fair_co2_only(emissions=emissions)
+
+    T_truth = xr.DataArray([0.        , 0.00464001, 0.01451917, 0.02775184,
+                            0.04310335, 0.05982477, 0.07744928, 0.09567989,
+                            0.11432504, 0.13325952, 0.15239999],
+                        coords={"timebounds":np.linspace(2009.5, 2019.5, 11)})
+
+    C_truth = xr.DataArray([278.3       , 281.98713205, 284.96432983,
+                            287.67924614, 290.23401333, 292.66883373,
+                            295.00890336, 297.27301864, 299.47583696,
+                            301.62892913, 303.74148527],
+                        coords={"timebounds":np.linspace(2009.5, 2019.5, 11)})
+
+    F_truth = xr.DataArray([0.        , 0.07393624, 0.13293446, 0.18620025,
+                            0.23586687, 0.28279642, 0.32753321, 0.37048144,
+                            0.41195413, 0.45219685, 0.4914037],
+                        coords={"timebounds":np.linspace(2009.5, 2019.5, 11)})
+
+    xr.testing.assert_allclose(T, T_truth)
+    xr.testing.assert_allclose(C, C_truth)
+    xr.testing.assert_allclose(F, F_truth)

--- a/agrifoodpy/land/model.py
+++ b/agrifoodpy/land/model.py
@@ -61,7 +61,7 @@ def carbon_sequestration(land_da, categories,
         Fully grown silvopasture land carbon sequestration expressed in
         [t CO2e / ha / year]    
     years : int, array
-        Year range length, or array of years for which the sequestratio is
+        Year range length, or array of years for which the sequestration is
         computed. If not given, stationary maximum values are returned 
     growth_timescale : float
         Time in years for land to reach full sequestration potential
@@ -93,12 +93,16 @@ def carbon_sequestration(land_da, categories,
     area_category = pixel_count_category * 100
     
     if years is not None:
-        # and then the sequestration as a function of time    
-        y0 = 0
-        y1 = 0
-        y2 = growth_timescale
-        y3 = years
-        scale = scaling.linear_scale(y0, y1, y2, y3, 0, 1)
+        # single scalar value
+        if np.isscalar(years):
+            scale = scaling.linear_scale(0, 0, growth_timescale, years, 0, 1)
+        # year range
+        else:
+            y0 = np.max((0, np.min(years)))
+            y1 = np.max((0, np.min(years)))
+            y2 = growth_timescale + y1
+            y3 = np.max(years)
+            scale = scaling.linear_scale(y0, y1, y2, y3, 0, 1)
     else:
         scale = 1
     
@@ -126,14 +130,3 @@ def carbon_sequestration(land_da, categories,
     })
     
     return sequestration_dataset
-
-def production_from_land():
-    """Food balance sheet from land use.
-
-    Generates a production sheet dataarray from a land dataarray or dataset
-    describing the land use at any given position and, optionally, a map
-    describing yield per position.
-
-
-
-    """

--- a/agrifoodpy/utils/scaling.py
+++ b/agrifoodpy/utils/scaling.py
@@ -33,7 +33,6 @@ def logistic_scale(y0, y1, y2, y3, c_init, c_end):
     # Set values between y1 and y2 using a logistic curve
     var_segment = np.logical_and(years >= y1, years < y2)
     t = (years[var_segment] - y1) / (y2 - y1)
-    print(t)
     values[var_segment] = c_init + \
                           (c_end - c_init) *(1 / (1 + np.exp(-10 * (t - 0.5))))
 


### PR DESCRIPTION
This PR fixes a few issues with some of the modules on AgriFoodPy

Food:
- Fixed the `balance_scaling` model to correctly scale and add quantities between different elements of the Food Balance Sheet datasets
- Fixes to plotting labels

Impact:
- A few typos
- Tests for `fbs_impacts`

Land:
- Fixes to the year range input on the `carbon_sequestration` model

Base class:
- Added missing tests