### PR TITLE
Fixes for sphinx-gallery docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -33,3 +33,6 @@ sphinx:
 python:
    install:
    - requirements: docs/requirements.txt
+   # Install our python package before building the docs
+   - method: pip
+     path: .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,9 +7,9 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'agrifoodpy'
-copyright = '2023, Juan P. Cordero'
+copyright = '2023, AgriFoodPy developers'
 author = 'Juan P. Cordero'
-release = '0.0.1'
+release = '0.1.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,6 @@ sphinx-autoapi
 sphinx_rtd_theme
 myst-parser
 sphinx-gallery
+
+netcdf4
+git+https://github.com/FixOurFood/agrifoodpy-data.git@importable


### PR DESCRIPTION
This fixes the failing automatic documentation building in readthedocs by installing the package from the source directory and adding a couple of missing dependencies manually.

It also fixes licence and version information in the `conf.py` file  