### PR TITLE
Fixed add_ routines, plot_years, reworked examples

### DIFF
--- a/agrifoodpy/array_accessor.py
+++ b/agrifoodpy/array_accessor.py
@@ -18,7 +18,6 @@ class XarrayAccessorBase(object):
         ----------
         items : list, int, string
             list of item names to be added to the data
-        
         copy_from : list, int, string, optional
             If provided, this is the list of items already on the array
             to copy data from.
@@ -37,7 +36,6 @@ class XarrayAccessorBase(object):
         # Check for duplicates
         indexes = np.unique(items, return_index=True)[1]
         items = [items[index] for index in sorted(indexes)] #issues with np.unique
-        
 
         new_items = xr.DataArray(data = np.ones(len(items)),
                                 coords = {"Item":items})
@@ -62,7 +60,7 @@ class XarrayAccessorBase(object):
 
         Parameters
         ----------
-        new_regions : list, int, string
+        regions : list, int, string
             list of region names to be added to the data
         copy_from : list, int, string
             If provided, this is the list of regions already on the object to
@@ -78,6 +76,9 @@ class XarrayAccessorBase(object):
         """
         
         fbs = self._obj
+
+        if np.isscalar(regions):
+            regions = [regions]
 
         indexes = np.unique(regions, return_index=True)[1]
         regions = [regions[index] for index in sorted(indexes)]
@@ -121,15 +122,25 @@ class XarrayAccessorBase(object):
 
         fbs = self._obj
 
+        if np.isscalar(years):
+            years = [years]
+
         indexes = np.unique(years, return_index=True)[1]
         years = [years[index] for index in sorted(indexes)]
         
-        if projection == "empty":
-            data = np.zeros(len(years))*np.nan
-        elif projection == "constant":
-            data = np.ones(len(years))
+        if isinstance(projection, str):
+            if projection == "empty":
+                data = np.zeros(len(years))*np.nan
+            elif projection == "constant":
+                data = np.ones(len(years))
+            else:
+                raise ValueError("If a string, 'projection' can only be 'empty'\
+                                 or 'constant'")
+            
         else:
+            # Should raise an exception if sizes do not match
             data = np.ones(len(years)) * projection
+        
         
         new_years = xr.DataArray(data=data,
                                     coords = {"Year":years})

--- a/agrifoodpy/tests/test_base_class.py
+++ b/agrifoodpy/tests/test_base_class.py
@@ -14,6 +14,15 @@ def test_add_years():
     
     fbs = XarrayAccessorBase(ds)
 
+    # Test adding single year
+
+    result_single = fbs.add_years(new_years[0])
+    expected_years_single = np.concatenate([years, [new_years[0]]])
+
+    assert np.array_equal(result_single["Year"], expected_years_single)
+    assert np.isnan(result_single["data"].loc[{"Year":new_years[0]}].to_numpy()
+                    ).all()
+
     # Test adding years with "empty" projection
     result_empty = fbs.add_years(new_years, projection="empty")
 

--- a/examples/modules/plot_animal_consumption_scaling.py
+++ b/examples/modules/plot_animal_consumption_scaling.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from agrifoodpy_data.food import FAOSTAT
 
-from agrifoodpy.food.food import FoodBalanceSheet
+import agrifoodpy.food
 from agrifoodpy.food.model import balanced_scaling
 
 from matplotlib import pyplot as plt

--- a/examples/modules/plot_emissions_animal_scaling.py
+++ b/examples/modules/plot_emissions_animal_scaling.py
@@ -19,7 +19,7 @@ import xarray as xr
 from agrifoodpy_data.impact import PN18_FAOSTAT as PN18
 from agrifoodpy_data.food import FAOSTAT
 
-from agrifoodpy.food.food import FoodBalanceSheet, FoodElementSheet
+import agrifoodpy.food
 from agrifoodpy.impact.model import fbs_impacts
 
 from matplotlib import pyplot as plt
@@ -36,7 +36,7 @@ food = FAOSTAT.sel(Region=country_codes)["production"]
 ghg_emissions = PN18["GHG Emissions"] / 1e6
 food_emissions = fbs_impacts(food, ghg_emissions)
 
-ax = food_emissions.fes.plot_years(show="Region", labels=["UK", "USA"])
+ax = food_emissions.fbs.plot_years(show="Region", labels=["UK", "USA"])
 ax.set_xlabel("Year")
 ax.set_ylabel("GHG emissions Gt CO2e")
 
@@ -44,8 +44,8 @@ plt.show()
 
 #%%
 # We can also plot by item origin by using the group_sum accessor function
-food_emissions_origin = food_emissions.fes.group_sum("Item_origin")
-ax = food_emissions_origin.fes.plot_years(show="Item_origin", labels="show")
+food_emissions_origin = food_emissions.fbs.group_sum("Item_origin")
+ax = food_emissions_origin.fbs.plot_years(show="Item_origin", labels="show")
 ax.set_xlabel("Year")
 ax.set_ylabel("GHG emissions [Gt CO2e]")
 plt.show()
@@ -54,14 +54,14 @@ plt.show()
 # We can add an item to the emissions DataArray and a new list of years,
 # scaling the values linearly
 
-emissions_proj = food_emissions.fes.add_items(items=5000)
+emissions_proj = food_emissions.fbs.add_items(items=5000)
 emissions_proj.loc[{"Item":5000}] = 2*food_emissions.sel(Item=2731)
 
 proj = np.linspace(1, 1.5, num=10)
-emissions_proj = emissions_proj.fes.add_years(years=np.arange(2021,2031), projection="constant")
+emissions_proj = emissions_proj.fbs.add_years(years=np.arange(2021,2031), projection="constant")
 emissions_proj.loc[{"Year":np.arange(2021,2031)}] *= xr.DataArray(np.linspace(1, 1.1, num=10), coords={"Year":np.arange(2021,2031)})
-emissions_by_origin_proj = emissions_proj.fes.group_sum("Item_origin")
-ax = emissions_by_origin_proj.fes.plot_years(show="Item_origin", labels="show")
+emissions_by_origin_proj = emissions_proj.fbs.group_sum("Item_origin")
+ax = emissions_by_origin_proj.fbs.plot_years(show="Item_origin", labels="show")
 
 ax.set_xlabel("Year")
 ax.set_ylabel("GHG emissions [Gt CO2e]")

--- a/examples/modules/plot_reforest_ALC_4_5.py
+++ b/examples/modules/plot_reforest_ALC_4_5.py
@@ -24,8 +24,7 @@ from agrifoodpy_data.land import UKCEH_LC_1000 as LC, ALC_1000 as ALC
 
 from agrifoodpy.land.land import LandDataArray
 from agrifoodpy.land.model import land_sequestration
-
-from agrifoodpy.food.food import FoodElementSheet
+import agrifoodpy.food
 
 from matplotlib import pyplot as plt
 
@@ -64,7 +63,7 @@ co2e_seq = land_sequestration(land_use, [1,2], max_seq=seq_forest,
                      years = np.arange(2020,2070),
                      growth_timescale=25)
 
-ax = co2e_seq.fes.plot_years()
+ax = co2e_seq.fbs.plot_years()
 ax.set_ylabel("[t CO2 / yr]")
 ax.set_xlabel("Year")
 plt.show()


### PR DESCRIPTION
This PR fixes a few issues with the add_years, add_items and add_regions methods.
It also fixed a few issues with the plot_years functions and renamed the DataArray food accessor to fbs, since they can share names, which adds simplicity.

Also reworked the examples to adjust for these changes.

This fixes #49 