### PR TITLE
Plot tests, fixed plot and SSR/IDR functionality

### DIFF
--- a/agrifoodpy/land/tests/test_land.py
+++ b/agrifoodpy/land/tests/test_land.py
@@ -2,6 +2,7 @@ import numpy as np
 import xarray as xr
 from agrifoodpy.land.land import LandDataArray
 import pytest
+import matplotlib.pyplot as plt
 
 def test_area_by_type():
     
@@ -159,3 +160,13 @@ def test_category_match():
     # Example with non-matching values
     result_non_matching = land_left.category_match(da_right, values_left=4)
     assert np.all(result_non_matching.isnull())
+
+def test_plot():
+    
+    data = np.random.rand(4, 5)
+    da = xr.DataArray(data, dims=['x', 'y'])
+    land = LandDataArray(da)
+    
+    # Test default plot
+    ax = land.plot()
+    assert isinstance(ax, plt.Axes)    


### PR DESCRIPTION
This PR adresses some issues on the main AgriFoodPy repo:

1. #57 : Now `plot_bars` can be used with a Non-dimension coordinate present in the dataset. This allows the function to dissagregate by a label coordinate. It uses `group_sum` to convert to a new `fbs` and recursively calls itself on the new `fbs`
2. #59 : The definition for domestic use in `SSR` and `IDR` is more flexible. It can be provided either explicitly or by providing the names of the `production`, `imports` and `exports` dataarrays 
3. We did not have any test for the plot functions `plot_bars` and `plot_years`. Implemented a few unit tests using the `lines` and `patches` generated on each ax.

It should also be possible to generate unit tests for the `land.plot` accessor method. I'll leave this PR open in the meantime and perhaps work on this soon.