### PR TITLE
Action names, add setuptools to requirements

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -1,4 +1,4 @@
-name: Python Package using Conda
+name: Tests
 
 on: [push, pull_request]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-requires = tox-conda
+requires =
+    tox-conda
+    setuptools
 envlist =
 	py{39,310}-test{,-latest,-oldest}
     build_docs


### PR DESCRIPTION
# Description
This PR changes the name of the GitHub action to run tests from "Python Package using Conda" to a more generic "Tests"
Also added `setuptools` as a requirement in the `tox` configuration file to fix a missing package error when running tox