### PR TITLE
fixed issue in reforestation example

### DIFF
--- a/examples/modules/plot_reforest_ALC_4_5.py
+++ b/examples/modules/plot_reforest_ALC_4_5.py
@@ -30,6 +30,7 @@ from matplotlib import pyplot as plt
 
 land_use = LC.copy(deep=True)
 land_use = land_use["dominant_aggregate"]
+ALC = ALC.grade
 
 f, axes = plt.subplots(1, 2, sharey=True)
 plt.subplots_adjust(wspace=0)


### PR DESCRIPTION
## Description

This PR fixes an issue with the Reforestation example in the Sphinx documentation.
It addresses the issue raised in #70, part of the JOSS review https://github.com/openjournals/joss-reviews/issues/6305

The problem was caused by a change in the agrifoodpy_data package causing the ALC object to be a Dataset instead of a DataArray. The former does not have the `land` accessor defined, as it is intended only for DataArray with x and y coordinates.