### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -9,9 +9,9 @@ jobs:
       max-parallel: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: Add conda to system path

--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -20,6 +20,7 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
+        conda install -y python=3.9
         conda env update --file environment.yml --name base
     - name: Test with tox
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -4,15 +4,15 @@ channels:
   - defaults
 
 dependencies:
-  - python>=3.9
-  - pip
-  - numpy
-  - netcdf4
-  - xarray
-  - jupyter
-  - ipython
-  - pandas
-  - matplotlib
-  - pytest
+  - python>=3.10
+  - pip>=24.0
+  - numpy>=1.26.4
+  - netcdf4>=1.6.2
+  - xarray>=2023.6.0
+  - jupyter>=1.0.0
+  - ipython>=8.15.0
+  - pandas>=2.2.1
+  - matplotlib>=3.8.4
+  - pytest>=7.4.0
   - pip:
-    - fair
+    - fair>=2.1.4

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 
 dependencies:
-  - python>=3.10
+  - python>=3.9
   - pip>=24.0
   - numpy>=1.26.4
   - netcdf4>=1.6.2


### PR DESCRIPTION
Updated GitHub deprecated Node 16 actions and added version requirements to the `environment.yml` environment file for tox-conda unit testing and documentation building.

This addresses #72 

