### PR TITLE
land plots and scale add fixes

### DIFF
--- a/agrifoodpy/impact/model.py
+++ b/agrifoodpy/impact/model.py
@@ -112,7 +112,7 @@ def fair_co2_only(emissions):
     
     f.emissions.loc[{"scenario":"default",
                      "specie":"CO2",
-                     "config":"default"}] = emissions
+                     "config":"default"}] = emissions.to_numpy()
     
     # Run and return
     f.run(progress=False)

--- a/agrifoodpy/land/land.py
+++ b/agrifoodpy/land/land.py
@@ -3,7 +3,10 @@
 
 import numpy as np
 import xarray as xr
+import matplotlib
 import matplotlib.pyplot as plt
+from matplotlib import colors as mcolors
+import matplotlib.patches as mpatches
 
 @xr.register_dataarray_accessor("land")
 class LandDataArray:
@@ -22,16 +25,30 @@ class LandDataArray:
         if "x" not in obj.dims or "y" not in obj.dims:
             raise AttributeError("Land array must have 'x' and 'y' dimensions")
 
-    def plot(self, ax=None, **kwargs):
+    def plot(self, ax=None, class_coord=None, colors=None, labels=None,
+             **kwargs):
         """Plot a LandDataArray
         
         Generates a plot of a LandDataArray using matplotlib imshow, without
         interpolation and setting the origin low to align north at the top.
+        If a dominant classification map type is provided, the plot will be
+        coloured accordingly. If a class percentage map is provided, the plot
+        will be coloured according to the dominant class on each pixel.
 
         Parameters
         ----------
         ax : matplotlib.pyplot.Artist
             Axes on which to draw the plot
+        class_coord : string
+            Name of the coordinate to use as land classes. If not provided, the
+            first non spatial coordinate is used.
+        colors : list of strings
+            Dictionary of colors to use for each land class. If not provided,
+            the default matplotlib colour map is used.
+        labels : list of strings
+            Dictionary of labels to use for each land class. If not provided and
+            the map is a class percentage map, the coordinate values are used
+            as labels.
         **kwargs : dict
             Style options to be passed to the imshow function.
         
@@ -45,8 +62,24 @@ class LandDataArray:
         if ax is None:
             f, ax = plt.subplots()
 
-        # Get plot ranges
+        # Check the map type by checking if there are any additional coordinates
+        extra_coords = [dim for dim in map.dims if dim not in ["x", "y"]]
+        if len(extra_coords) >= 1:
+            if labels is None:
+                labels = map[extra_coords[0]].values
+            map = self.dominant_class(class_coord=class_coord)
+        else:
+            labels = np.unique(map.values)
 
+        if colors is None:
+            colors = [f"C{i}" for i in np.arange(len(labels))]
+
+        # Create a colour map
+        cmap = mcolors.ListedColormap(colors)
+        bounds = np.linspace(-0.5, len(colors), len(colors) + 1)
+        norm = mcolors.BoundaryNorm(bounds, cmap.N)
+
+        # Get plot ranges
         dx_low = (map.x.values[1] - map.x.values[0])/2
         dx_high = (map.x.values[-1] - map.x.values[-2])/2
         dy_low = (map.y.values[1] - map.y.values[0])/2
@@ -56,7 +89,13 @@ class LandDataArray:
         ymin, ymax = map.y.values[[0, -1]]
 
         ax.imshow(map, interpolation="none", origin="lower",
-                  extent=[xmin-dx_low, xmax+dx_high, ymin-dy_low, ymax+dy_high])
+                  extent=[xmin-dx_low, xmax+dx_high, ymin-dy_low, ymax+dy_high],
+                  cmap=cmap, norm=norm)
+        
+        patches = [mpatches.Patch(color=colors[i],
+                                  label=labels[i]) for i in np.arange(len(labels))]
+        
+        ax.legend(handles=patches, loc="best")
         
         return ax
         
@@ -217,3 +256,34 @@ class LandDataArray:
         category_match = map_left.where(left_match).where(right_match)
 
         return category_match
+
+    def dominant_class(self, class_coord=None, return_index=False):
+        """Returns a land DataArray with the dominant land class for each pixel.
+
+        Parameters
+        ----------
+        class_coord : string
+            Name of the land class coordinate. If not set, the first coordinate
+            is used.
+        return_index : bool
+            If True, the index of the dominant class is returned instead of the
+            class value.
+
+        Returns
+        -------
+        xarray.DataArray
+            Land DataArray with the dominant land class for each pixel.
+        """
+
+        map = self._obj
+
+        if class_coord is None:
+            class_coord = [dim for dim in map.dims if dim not in ["x", "y"]][0]
+
+        if return_index:
+            len_class = len(map[class_coord].values)
+            map = map.assign_coords({class_coord:np.arange(len_class)})
+
+        map = map.idxmax(dim=class_coord, skipna=True)
+
+        return map

--- a/agrifoodpy/land/tests/test_land.py
+++ b/agrifoodpy/land/tests/test_land.py
@@ -169,4 +169,35 @@ def test_plot():
     
     # Test default plot
     ax = land.plot()
-    assert isinstance(ax, plt.Axes)    
+    assert isinstance(ax, plt.Axes)
+
+def test_dominant_class():
+    classes = ["a", "b", "c"]
+    coords = {"x": [0, 1, 2, 3], "y": [0, 1, 2], "class": classes}
+    coords_index = {"x": [0, 1, 2, 3], "y": [0, 1, 2]}
+    
+    data = np.random.rand(len(coords["x"]),
+                          len(coords["y"]),
+                          len(coords["class"]))
+    
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+
+    # Test dominant class without coord name
+    result_no_coord = land.dominant_class()
+    assert result_no_coord.equals(da.idxmax(dim="class"))
+
+    # Test dominant class with coord name
+    result_coord = land.dominant_class(class_coord="class")
+    assert result_coord.equals(da.idxmax(dim="class"))
+
+    # Test dominant class with non-matching coord name
+    with pytest.raises(KeyError):
+        result_non_matching = land.dominant_class(class_coord="non_matching")
+
+    # Test with return index set to True
+    result_return_index = land.dominant_class(return_index=True)
+    result_return_index_truth = xr.DataArray(np.argmax(data, axis=2),
+                                             coords=coords_index)
+
+    assert result_return_index.equals(result_return_index_truth)


### PR DESCRIPTION
A few improvements to the land and food modules:

- The `scale_add` method in the `FoodBalanceSheet` now takes multiple elements to add quantities to from the input element. Each one takes its own `add` parameter, and a new parameter called `elasticity`, which can be used to distribute the contributions from each element arbitrarily.
- The `LandDataArray.plot` function now recognizes whether the DataArray being used is a dominant or percentage type, and plots them accordingly. 
- Added the `LandDataArray.dominant_class` function to convert a percentage type map into a dominant type map.