### PR TITLE
CLI script and config parser

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -3,26 +3,34 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  build-linux:
+  tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      fail-fast: false
+      matrix:
+        # Define the specific slices you want to test
+        include:
+          - python: '3.9'
+            toxenv: py39-oldest
+
+          - python: '3.9'
+            toxenv: py39-latest
+
+          - python: '3.14'
+            toxenv: py314-latest
+
+          - python: '3.14'
+            toxenv: build_docs
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+    - name: Set up Python ${{matrix.python}}
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
+        python-version: ${{matrix.python}}
+
     - name: Install dependencies
-      run: |
-        conda install -y python=3.9
-        conda env update --file environment.yml --name base
+      run: pip install tox
+
     - name: Test with tox
-      run: |
-        pip install tox
-        tox run
+      run: tox -e ${{matrix.toxenv}}

--- a/agrifoodpy/food/food.py
+++ b/agrifoodpy/food/food.py
@@ -71,13 +71,16 @@ def FoodSupply(
               "Year": _years}
 
     # find positions in output array to organize data
-    ii = [np.searchsorted(_items, items), np.searchsorted(_years, years)]
+    ii = [
+        np.atleast_1d(np.searchsorted(_items, items)),
+        np.atleast_1d(np.searchsorted(_years, years))
+    ]
     size = (len(_items), len(_years))
 
     # If regions and are provided, add the coordinate information
     if regions is not None:
         _regions = np.unique(regions)
-        ii.append(np.searchsorted(_regions, regions))
+        ii.append(np.atleast_1d(np.searchsorted(_regions, regions)))
         size = size + (len(_regions),)
         coords["Region"] = _regions
 

--- a/agrifoodpy/food/tests/test_food.py
+++ b/agrifoodpy/food/tests/test_food.py
@@ -474,11 +474,15 @@ def test_plot_bars():
        
 def test_plot_years():
     
-    da = xr.DataArray(np.arange(15).reshape(5,3),
-                        coords=[('Year', [2010, 2011, 2012, 2013, 2014]),
-                                ('Region', ['A', 'B', 'C'])],
-                        dims=['Year', 'Region'])
-    
+    years = [2019, 2010, 2011, 2012, 2013, 2014]
+    regions = ['A', 'B', 'C']
+
+    da = xr.DataArray(
+        np.arange(len(years)*len(regions)).reshape(len(years), len(regions)),
+        coords=[('Year', years),
+                ('Region', regions)],
+        dims=['Year', 'Region'])
+
     fbs = FoodElementSheet(da)
 
     # Test default call

--- a/agrifoodpy/land/land.py
+++ b/agrifoodpy/land/land.py
@@ -277,8 +277,8 @@ class LandDataArray:
 
         shape = map_left.shape
 
-        left_match = np.in1d(map_left, values_left).reshape(shape)
-        right_match = np.in1d(map_right, values_right).reshape(shape)
+        left_match = np.isin(map_left, values_left).reshape(shape)
+        right_match = np.isin(map_right, values_right).reshape(shape)
 
         category_match = map_left.where(left_match).where(right_match)
 

--- a/agrifoodpy/pipeline/cli.py
+++ b/agrifoodpy/pipeline/cli.py
@@ -1,0 +1,58 @@
+import argparse
+import json
+from .pipeline import Pipeline
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run an AgriFoodPy pipeline from a configuration file."
+    )
+
+    parser.add_argument(
+        "config",
+        help="Pipeline configuration YAML file"
+    )
+
+    parser.add_argument(
+        "--output",
+        help="Optional output file to store the datablock as JSON",
+        default=None
+    )
+
+    parser.add_argument(
+        "--show-datablock",
+        action="store_true",
+        help="Print the final datablock to stdout"
+    )
+
+
+    parser.add_argument(
+        "--show-nodes",
+        action="store_true",
+        help="Print the final datablock to stdout"
+    )
+
+    parser.add_argument(
+        "--norun",
+        action="store_true",
+        help="Do not run the pipeline"
+    )
+
+    args = parser.parse_args()
+
+    pipeline = Pipeline.read(args.config)
+
+    if args.show_nodes:
+        pipeline.print_nodes()
+
+    if not args.norun:
+        pipeline.run()
+
+    datablock = pipeline.datablock
+
+    if args.show_datablock:
+        print(json.dumps(datablock, indent=2, default=str))
+
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(datablock, f, indent=2, default=str)

--- a/agrifoodpy/pipeline/cli.py
+++ b/agrifoodpy/pipeline/cli.py
@@ -1,9 +1,10 @@
 import argparse
 import json
+import sys
 from .pipeline import Pipeline
 
 
-def main():
+def main(args=None):
     parser = argparse.ArgumentParser(
         description="Run an AgriFoodPy pipeline from a configuration file."
     )
@@ -14,45 +15,65 @@ def main():
     )
 
     parser.add_argument(
+        "-o",
         "--output",
         help="Optional output file to store the datablock as JSON",
         default=None
     )
 
     parser.add_argument(
-        "--show-datablock",
+        "--nodes",
         action="store_true",
-        help="Print the final datablock to stdout"
-    )
-
-
-    parser.add_argument(
-        "--show-nodes",
-        action="store_true",
-        help="Print the final datablock to stdout"
+        help="Print the nodes and parameters to stdout"
     )
 
     parser.add_argument(
-        "--norun",
-        action="store_true",
+        "--no-run",
+        action="store_false",
         help="Do not run the pipeline"
     )
 
-    args = parser.parse_args()
+    parser.add_argument(
+        "--from-node",
+        type=int,
+        help="Index of the first node to be executed"
+    )
+
+    parser.add_argument(
+        "--to-node",
+        type=int,
+        help="Index of the last node to be executed"
+    )
+
+    parser.add_argument(
+        "--skip-nodes",
+        nargs="+",
+        type=int,
+        help="List of nodes to be skipped in the pipeline execution"
+    )
+
+    # get system args if none passed
+    if args is None:
+        args = sys.argv[1:]
+
+    args = parser.parse_args(args or ['--help'])
 
     pipeline = Pipeline.read(args.config)
 
-    if args.show_nodes:
+    if args.nodes:
         pipeline.print_nodes()
 
-    if not args.norun:
-        pipeline.run()
+    from_node = args.from_node if args.from_node is not None else 0
+    to_node = args.to_node if args.to_node is not None else len(pipeline.nodes)
+    skip_nodes = args.skip_nodes if args.skip_nodes is not None else None
+
+    if args.no_run:
+        pipeline.run(from_node=from_node, to_node=to_node, skip=skip_nodes)
 
     datablock = pipeline.datablock
 
-    if args.show_datablock:
-        print(json.dumps(datablock, indent=2, default=str))
-
-    if args.output:
+    if args.output is not None:
         with open(args.output, "w") as f:
             json.dump(datablock, f, indent=2, default=str)
+
+    return 0

--- a/agrifoodpy/pipeline/cli.py
+++ b/agrifoodpy/pipeline/cli.py
@@ -58,20 +58,24 @@ def main(args=None):
 
     args = parser.parse_args(args or ['--help'])
 
+    # read pipeline configuration and set pipeline object
     pipeline = Pipeline.read(args.config)
-
-    if args.nodes:
-        pipeline.print_nodes()
 
     from_node = args.from_node if args.from_node is not None else 0
     to_node = args.to_node if args.to_node is not None else len(pipeline.nodes)
     skip_nodes = args.skip_nodes if args.skip_nodes is not None else None
 
+    # print the nodes and parameters if requested
+    if args.nodes:
+        pipeline.print_nodes()
+
+    # run the pipeline if not skipped
     if args.no_run:
         pipeline.run(from_node=from_node, to_node=to_node, skip=skip_nodes)
 
     datablock = pipeline.datablock
 
+    # write outputs
     if args.output is not None:
         with open(args.output, "w") as f:
             json.dump(datablock, f, indent=2, default=str)

--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -52,14 +52,15 @@ class Pipeline():
 
         pipeline = cls()
 
-        for step in config["nodes"]:
-            func = cls._load_function(step["function"])
-            params = step.get("params", {})
-            name = step.get("name", func.__name__)
+        if config is not None:
+            for step in config["nodes"]:
+                func = cls._load_function(step["function"])
+                params = step.get("params", {})
+                name = step.get("name", func.__name__)
 
-            pipeline.nodes.append(func)
-            pipeline.params.append(params)
-            pipeline.names.append(name)
+                pipeline.nodes.append(func)
+                pipeline.params.append(params)
+                pipeline.names.append(name)
 
         return pipeline
 

--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -48,7 +48,7 @@ class Pipeline():
         """
 
         with open(filename, "r") as f:
-            config = yaml.safe_load(f)
+            config = yaml.load(f, Loader=yaml.FullLoader)
 
         pipeline = cls()
 

--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -8,11 +8,14 @@ import copy
 from functools import wraps
 from inspect import signature
 import time
+import yaml
+import importlib
 
 
 class Pipeline():
     '''Class for constructing and running pipelines of functions with
     individual sets of parameters.'''
+
     def __init__(self, datablock=None):
         self.nodes = []
         self.params = []
@@ -22,9 +25,16 @@ class Pipeline():
         else:
             self.datablock = {}
 
+    @staticmethod
+    def _load_function(path):
+        """Load a function from a dotted path."""
+        module_path, func_name = path.rsplit(".", 1)
+        module = importlib.import_module(module_path)
+        return getattr(module, func_name)
+
     @classmethod
     def read(cls, filename):
-        """Read a pipeline from a configuration file
+        """Read a pipeline configuration from a YAML file
 
         Parameters
         ----------
@@ -36,7 +46,22 @@ class Pipeline():
         pipeline : Pipeline
             The pipeline object.
         """
-        raise NotImplementedError("This method is not yet implemented.")
+
+        with open(filename, "r") as f:
+            config = yaml.safe_load(f)
+
+        pipeline = cls()
+
+        for step in config["nodes"]:
+            func = cls._load_function(step["function"])
+            params = step.get("params", {})
+            name = step.get("name", func.__name__)
+
+            pipeline.nodes.append(func)
+            pipeline.params.append(params)
+            pipeline.names.append(name)
+
+        return pipeline
 
     def datablock_write(self, path, value):
         """Writes a single value to the datablock at the specified path.
@@ -118,7 +143,6 @@ class Pipeline():
         del self.params[index]
         del self.names[index]
 
-
     def run(self, from_node=0, to_node=None, skip=None, timing=False):
         """Runs the pipeline
 
@@ -130,7 +154,7 @@ class Pipeline():
         to_node : int, optional
             The index of the last node to be executed. If not provided, all
             nodes will be executed
-        
+
         skip : list of int, optional
             List of node indices to skip during execution. Defaults to None.
 
@@ -175,18 +199,17 @@ class Pipeline():
 
     def print_nodes(self, show_params=True):
         """Prints the list of nodes associated with a Pipeline instance.
-        
+
         Parameters
         ----------
         show_params : bool, optional
             If True, displays the parameters associated with each node.
         """
 
-
         if not self.nodes:
             print("Pipeline is empty.")
             return
-        
+
         print("Pipeline nodes:")
         for i, (name, node, params) in enumerate(zip(self.names, self.nodes, self.params)):
             node_name = getattr(node, "__name__", repr(node))
@@ -194,6 +217,7 @@ class Pipeline():
             if show_params and params:
                 for k, v in params.items():
                     print(f"    {k} = {v}")
+
 
 def standalone(input_keys, return_keys):
     """ Decorator to make a pipeline node available as a standalone function

--- a/agrifoodpy/pipeline/tests/data/test_config.yml
+++ b/agrifoodpy/pipeline/tests/data/test_config.yml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    params:
+      key: test_write
+      value: 200
+    name: writing to datablock

--- a/agrifoodpy/pipeline/tests/test_cli.py
+++ b/agrifoodpy/pipeline/tests/test_cli.py
@@ -1,0 +1,27 @@
+from agrifoodpy.pipeline.cli import main
+import pytest
+import os
+
+def test_cli(tmp_path):
+
+    # Test with no arguments
+    with pytest.raises(SystemExit) as e:
+        main()
+    assert e.value.code == 0
+
+    # Argparse help
+    with pytest.raises(SystemExit) as e:
+        main(['--help'])
+    assert e.value.code == 0
+
+    # Process test config file
+    script_dir = os.path.dirname(__file__)
+    config_filename = os.path.join(script_dir, "data/empty_config.yml")   
+    output_filename = str(tmp_path / 'empty.json')
+    assert main([config_filename, '-o', output_filename]) == 0
+
+    # Process test config file
+    script_dir = os.path.dirname(__file__)
+    config_filename = os.path.join(script_dir, "data/test_config.yml")   
+    output_filename = str(tmp_path / 'test.json')
+    assert main([config_filename, '-o', output_filename]) == 0

--- a/agrifoodpy/utils/nodes.py
+++ b/agrifoodpy/utils/nodes.py
@@ -1,5 +1,8 @@
 import copy
+import json
+import os
 import xarray as xr
+import numpy as np
 import importlib
 
 from ..pipeline import standalone
@@ -285,5 +288,173 @@ def load_dataset(
 
     # Add dataset to datablock
     datablock[datablock_path] = dataset * scale
+
+    return datablock
+
+def _tuple_to_str(tup):
+    return ".".join(str(x) for x in tup)
+
+def write_json(datablock, key, path, indent=2):
+    """Writes a datablock value to a JSON file.
+
+    Parameters
+    ----------
+    datablock : dict
+        The datablock to read from.
+    key : str, tuple or list
+        List of datablock keys (or tuple of keys for nested access) of the
+        value to write.
+    path : str
+        Output file path.
+    indent : int, optional
+        JSON indentation level. Defaults to 2.
+
+    Returns
+    -------
+    datablock : dict
+        Unmodified datablock.
+    """
+
+    def _default(o):
+        if isinstance(o, (xr.Dataset, xr.DataArray)):
+            return o.to_dict()
+        if isinstance(o, np.ndarray):
+            return o.tolist()
+        if isinstance(o, np.integer):
+            return int(o)
+        if isinstance(o, np.floating):
+            return float(o)
+        return str(o)
+
+    if isinstance(key, str):
+        key = [key]
+    elif isinstance(key, tuple):
+        key = [key]
+
+    obj_dict = {}
+
+    for obj_key in key:
+        if isinstance(obj_key, tuple):
+            obj_dict[_tuple_to_str(obj_key)] = get_dict(datablock, obj_key)
+        else:
+            obj_dict[obj_key] = get_dict(datablock, obj_key)
+    
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+
+    with open(path, "w") as f:
+        json.dump(obj_dict, f, indent=indent, default=_default)
+
+    return datablock
+
+
+def write_netcdf(datablock, key, path):
+    """Writes a datablock xarray Dataset or DataArray to a NetCDF file.
+
+    Parameters
+    ----------
+    datablock : dict
+        The datablock to read from.
+    key : str or tuple
+        Datablock key (or tuple of keys for nested access) of the dataset to
+        write.
+    path : str
+        Output file path.
+
+    Returns
+    -------
+    datablock : dict
+        Unmodified datablock.
+    """
+
+    obj = get_dict(datablock, key)
+
+    if not isinstance(obj, (xr.Dataset, xr.DataArray)):
+        raise TypeError(
+            f"write_netcdf only supports xarray Dataset or DataArray objects. "
+            f"Got {type(obj).__name__} instead."
+        )
+
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    obj.to_netcdf(path)
+
+    return datablock
+
+
+def write_csv(datablock, key, path, index=True):
+    """Writes a datablock value to a CSV file.
+
+    Supports xarray Dataset, xarray DataArray, pandas DataFrame and Series.
+    xarray objects are converted to a DataFrame before writing; the
+    multi-index produced by that conversion (which encodes coordinates) is
+    written when index=True.
+
+    Parameters
+    ----------
+    datablock : dict
+        The datablock to read from.
+    key : str, list or tuple
+        Datablock key (or tuple of keys for nested access) of the value to write.
+    path : str
+        Output file path.
+    index : bool, optional
+        Whether to write the row index. Defaults to True.
+
+    Returns
+    -------
+    datablock : dict
+        Unmodified datablock.
+    """
+    import pandas as pd
+
+    obj = get_dict(datablock, key)
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+
+    if isinstance(obj, (xr.Dataset, xr.DataArray)):
+        try:
+            obj.to_dataframe().to_csv(path, index=index)
+        except ValueError:
+            # Unnamed DataArrays raise a ValueError.
+
+            if isinstance(key, tuple):
+                obj.name = key[-1]
+            else:
+                obj.name = str(key)
+                
+            obj.to_dataframe().to_csv(path, index=index)
+
+    elif isinstance(obj, (pd.DataFrame, pd.Series)):
+        obj.to_csv(path, index=index)
+    else:
+        raise TypeError(
+            f"write_csv does not support objects of type {type(obj).__name__}. "
+            "Expected xr.Dataset, xr.DataArray, pd.DataFrame, or pd.Series."
+        )
+
+    return datablock
+
+
+def write_text(datablock, key, path):
+    """Writes the string representation of a datablock value to a text file.
+
+    Parameters
+    ----------
+    datablock : dict
+        The datablock to read from.
+    key : str or tuple
+        Datablock key (or tuple of keys for nested access) of the value to write.
+    path : str
+        Output file path.
+
+    Returns
+    -------
+    datablock : dict
+        Unmodified datablock.
+    """
+
+    obj = get_dict(datablock, key)
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+
+    with open(path, "w") as f:
+        f.write(str(obj))
 
     return datablock

--- a/agrifoodpy/utils/nodes.py
+++ b/agrifoodpy/utils/nodes.py
@@ -414,12 +414,11 @@ def write_csv(datablock, key, path, index=True):
             obj.to_dataframe().to_csv(path, index=index)
         except ValueError:
             # Unnamed DataArrays raise a ValueError.
-
             if isinstance(key, tuple):
                 obj.name = key[-1]
             else:
                 obj.name = str(key)
-                
+
             obj.to_dataframe().to_csv(path, index=index)
 
     elif isinstance(obj, (pd.DataFrame, pd.Series)):

--- a/agrifoodpy/utils/tests/test_write_to_disk.py
+++ b/agrifoodpy/utils/tests/test_write_to_disk.py
@@ -1,0 +1,127 @@
+def test_write_csv():
+    from agrifoodpy.utils.nodes import write_csv
+    import pandas as pd
+    import xarray as xr
+
+    # Test unsupported type
+    datablock_unsupported = {"data": set([1, 2, 3])}
+    try:
+        write_csv(datablock_unsupported, key="data", path="test.csv")
+    except TypeError as e:
+        assert str(e) == "write_csv does not support objects of type set. Expected xr.Dataset, xr.DataArray, pd.DataFrame, or pd.Series."
+
+    # Test Pandas DataFrame
+    df = pd.DataFrame(
+        {
+            "Item": ["Beef", "Beef", "Apples", "Apples"],
+            "Year": [2020, 2021, 2020, 2021],
+            "production": [15, 20, 6, 7]
+        }
+    )
+
+    datablock_df = {"data": df}
+    path = "test_df_output.csv"
+
+    write_csv(datablock_df, key="data", path=path)
+
+    df = pd.read_csv(path, index_col=0, header=0)
+    assert df.shape == (4, 3)
+    assert list(df.columns) == ["Item", "Year", "production"]
+    assert df.iloc[0]["Item"] == "Beef"
+    assert df.iloc[0]["Year"] == 2020
+    assert df.iloc[0]["production"] == 15
+
+    assert df.iloc[1]["Item"] == "Beef"
+    assert df.iloc[1]["Year"] == 2021
+    assert df.iloc[1]["production"] == 20
+
+    # Test Pandas Series
+    series = pd.Series(
+        [15, 6, 30],
+        index=["Beef", "Apples", "Poultry"],
+        name="production",
+        )
+    
+    datablock_series = {"data": series}
+    path = "test_series_output.csv"
+
+    write_csv(datablock_series, key="data", path=path)
+
+    df = pd.read_csv(path, index_col=0, header=0)
+    assert df.shape == (3, 1)
+    assert list(df.columns) == ["production"]
+    assert df.loc["Beef", "production"] == 15
+    assert df.loc["Apples", "production"] == 6
+    assert df.loc["Poultry", "production"] == 30
+
+    # Test xarray Dataset
+    ds = xr.Dataset(
+        {
+            "production": (("Item", "Year"), [[15, 20], [6, 7]]),
+            "imports": (("Item", "Year"), [[4, 5], [1, 2]]),
+        },
+        coords={
+            "Item": ["Beef", "Apples"],
+            "Year": ["2020", "2021"],
+        },
+    )
+
+    datablock_ds = {"data": ds}
+    path = "test_ds_output.csv"
+
+    write_csv(datablock_ds, key="data", path=path)
+
+    df = pd.read_csv(path, header=0)
+
+    assert df.shape == (4, 4)
+    assert list(df.columns) == ["Item", "Year", "production", "imports"]
+    assert df.iloc[0]["Item"] == "Beef"
+    assert df.iloc[0]["Year"] == 2020
+    assert df.iloc[0]["production"] == 15
+    assert df.iloc[0]["imports"] == 4
+
+    # Test xarray DataArray
+    da = xr.DataArray(
+        [[15, 20], [6, 7]],
+        coords={
+            "Item": ["Beef", "Apples"],
+            "Year": ["2020", "2021"],
+        },
+        dims=["Item", "Year"],
+        name="production",
+    )
+
+    datablock_da = {"data": da}
+    path = "test_da_output.csv"
+
+    write_csv(datablock_da, key="data", path=path)
+
+    df = pd.read_csv(path, header=0)
+
+    assert df.shape == (4, 3)
+    assert list(df.columns) == ["Item", "Year", "production"]
+    assert df.iloc[0]["Item"] == "Beef"
+    assert df.iloc[0]["Year"] == 2020
+    assert df.iloc[0]["production"] == 15
+
+    # Test unnamed xarray DataArray
+    datablock_key = "data"
+
+    da_unnamed = xr.DataArray(
+        [[15, 20], [6, 7]],
+        coords={
+            "Item": ["Beef", "Apples"],
+            "Year": ["2020", "2021"],
+        },
+        dims=["Item", "Year"],
+    )
+
+    datablock_da_unnamed = {datablock_key: da_unnamed}
+    path = "test_da_unnamed_output.csv"
+
+    write_csv(datablock_da_unnamed, key=datablock_key, path=path)
+
+    df = pd.read_csv(path, header=0)
+
+    assert df.shape == (4, 3)
+    assert list(df.columns) == ["Item", "Year", datablock_key]

--- a/agrifoodpy/utils/tests/test_write_to_disk.py
+++ b/agrifoodpy/utils/tests/test_write_to_disk.py
@@ -1,4 +1,4 @@
-def test_write_csv():
+def test_write_csv(tmp_path):
     from agrifoodpy.utils.nodes import write_csv
     import pandas as pd
     import xarray as xr
@@ -6,7 +6,7 @@ def test_write_csv():
     # Test unsupported type
     datablock_unsupported = {"data": set([1, 2, 3])}
     try:
-        write_csv(datablock_unsupported, key="data", path="test.csv")
+        write_csv(datablock_unsupported, key="data", path=tmp_path / "test.csv")
     except TypeError as e:
         assert str(e) == "write_csv does not support objects of type set. Expected xr.Dataset, xr.DataArray, pd.DataFrame, or pd.Series."
 
@@ -20,7 +20,7 @@ def test_write_csv():
     )
 
     datablock_df = {"data": df}
-    path = "test_df_output.csv"
+    path = tmp_path / "test_df_output.csv"
 
     write_csv(datablock_df, key="data", path=path)
 
@@ -43,7 +43,7 @@ def test_write_csv():
         )
     
     datablock_series = {"data": series}
-    path = "test_series_output.csv"
+    path = tmp_path / "test_series_output.csv"
 
     write_csv(datablock_series, key="data", path=path)
 
@@ -67,7 +67,7 @@ def test_write_csv():
     )
 
     datablock_ds = {"data": ds}
-    path = "test_ds_output.csv"
+    path = tmp_path / "test_ds_output.csv"
 
     write_csv(datablock_ds, key="data", path=path)
 
@@ -92,7 +92,7 @@ def test_write_csv():
     )
 
     datablock_da = {"data": da}
-    path = "test_da_output.csv"
+    path = tmp_path / "test_da_output.csv"
 
     write_csv(datablock_da, key="data", path=path)
 
@@ -117,7 +117,7 @@ def test_write_csv():
     )
 
     datablock_da_unnamed = {datablock_key: da_unnamed}
-    path = "test_da_unnamed_output.csv"
+    path = tmp_path / "test_da_unnamed_output.csv"
 
     write_csv(datablock_da_unnamed, key=datablock_key, path=path)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,6 @@ extensions += ['sphinx_gallery.gen_gallery', ]
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',  # path to examples scripts
     'gallery_dirs': 'examples',      # path to gallery generated examples
-    'run_stale_examples': True,
+    'run_stale_examples': False,
     'download_all_examples': False,
 }

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -1,0 +1,53 @@
+.. _config_file:
+
+Command line tool
+=================
+
+The ``agrifoodpy`` command line tool allows you to run a pipeline of functions
+defined in a configuration file. This is useful for automating workflows and
+reproducibility. You can specify the configuration file and an output file for
+the results.
+
+Executing the command line tool
+-------------------------------
+
+To execute the command line tool, use the following syntax:
+
+.. code-block:: console
+
+    $ agrifoodpy <config_file.yml> -o <output_file.json>
+
+The following options are available for the command line tool:
+
+:\-o \-\-output: Specify the output file for the results. The output will be saved in JSON format.
+
+:\-\-nodes: Print the nodes and parameters to stdout
+
+:\-\-no-run: Do not run the pipeline
+
+:\-\-from-node: Index of the first node to be executed
+
+:\-\-to-node: Index of the last node to be executed
+
+:\-\-skip-nodes: List of nodes to be skipped in the pipeline execution
+
+
+Configuration files
+-------------------
+
+Configuration files are YAML files that define a pipeline of functions to be
+executed by the ``agrifoodpy`` command line tool. Each function is specified
+with its name and parameters, and the pipeline is executed in the order they
+are defined.
+
+.. literalinclude:: ../examples/cli/scaling_food_supply.yml
+  :language: YAML
+  :caption: Example of a configuration file for scaling a food balance sheet.
+
+Each node is defined with a function to execute, and its parameters and,
+optionally, a name. The function is specified in the format ``module.function``,
+where ``module`` is the name of the module containing the function,
+and ``function`` is the name of the function to be executed.
+The parameters are specified as a dictionary of key-value pairs,
+where the keys are the parameter names.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Welcome to agrifoodpy's documentation!
 
    install
    examples/index
-
+   config_file
    contributing
 
 .. include:: readme.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ myst-parser
 sphinx-gallery
 
 netcdf4
-git+https://github.com/FixOurFood/agrifoodpy-data.git@importable
+git+https://github.com/FixOurFood/agrifoodpy-data.git

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -3,4 +3,4 @@ Examples
 
 AgriFoodPy implements models and table manipulation methods to analyse and
 process agrifood data. In these examples we demonstrate the use of some of these
-methods and models using python scripts.  
+methods and models using python scripts, or a console script.

--- a/examples/cli/README.rst
+++ b/examples/cli/README.rst
@@ -1,0 +1,13 @@
+Command line tool
+-----------------
+
+``agrifoodpy`` is a command line script that runs a pipeline of functions
+defined in a config file.
+
+.. code-block:: console
+    
+    $ agrifoodpy examples/cli/scaling_food_supply.yml -o results.json
+
+For more information on how to configure a pipeline using configuration files
+and execute them using the ``agrifoodpy`` command line tool, see
+:ref:`config_file`.

--- a/examples/cli/scaling_food_supply.yml
+++ b/examples/cli/scaling_food_supply.yml
@@ -1,0 +1,66 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.load_dataset
+    name: "Load dataset"
+    params:
+      datablock_path: "food"
+      module: "agrifoodpy_data.food"
+      data_attr: "FAOSTAT"
+      coords: {
+            Item: [2731, 2511],
+            Year: [2019, 2020],
+            Region: 229}
+
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: "Add convertion factor from 1000 tonnes to kg"
+    params:
+      key: "tonnes_to_kg"
+      value: 1000000
+
+  - function: agrifoodpy.food.model.fbs_convert
+    name: "Convert fbs from 1000 tonnes to kg"
+    params:
+      fbs: "food"
+      convertion_arr: "tonnes_to_kg"
+
+  - function: agrifoodpy.food.model.SSR
+    name: "Calculate SSR"
+    params:
+      fbs: "food"
+      out_key: "SSR"
+
+  - function: agrifoodpy.food.model.IDR
+    name: "Calculate IDR"
+    params:
+      fbs: "food"
+      out_key: "IDR"
+
+  - function: agrifoodpy.utils.nodes.print_datablock
+    name: "Print SSR"
+    params:
+      key: "SSR"
+      method: "to_numpy"
+      preffix: "SSR: values "
+
+  - function: agrifoodpy.utils.nodes.add_items
+    name: "Add item names to the datablock"
+    params:
+      dataset: "food"
+      copy_from: 2731
+      items: {
+        "Item": 5000,
+        "Item_name": "Cultured meat",
+        "Item_group": "Cultured products",
+        "Item_origin": "Synthetic origin",
+      }
+
+  - function: agrifoodpy.utils.nodes.add_years
+    name: "Add years to the fbs"
+    params:
+      dataset: "food"
+      years: [2021, 2025, 2030]
+      projection: [1.1, 1.5, 10]
+
+  - function: agrifoodpy.utils.nodes.print_datablock
+    name: "Print FBS"
+    params:
+      key: "food"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ LONG_DESCRIPTION = (HERE / "README.md").read_text()
 LONG_DESC_TYPE = "text/markdown"
 
 INSTALL_REQUIRES = [
-      'numpy',
-      'pandas',
-      'xarray',
-      'matplotlib',
+    'numpy',
+    'pandas',
+    'xarray',
+    'matplotlib',
 ]
 
 setup(name=PACKAGE_NAME,
@@ -31,5 +31,10 @@ setup(name=PACKAGE_NAME,
       author_email=AUTHOR_EMAIL,
       url=URL,
       install_requires=INSTALL_REQUIRES,
-      packages=find_packages()
+      packages=find_packages(),
+      entry_points={
+          'console_scripts': [
+              'agrifoodpy = agrifoodpy.pipeline.cli:main',
+          ]
+      }
       )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ INSTALL_REQUIRES = [
     'pandas',
     'xarray',
     'matplotlib',
+    'pyyaml'
 ]
 
 setup(name=PACKAGE_NAME,

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,35 @@
 [tox]
-requires =
-    tox-conda
-    setuptools
+; requires =
+    ; tox-conda
+    ; setuptools
 envlist =
-	py{39,310}-test{,-latest,-oldest}
+	py{39,310,311,312,313,314}-{oldest,latest}
     build_docs
 
-[testenv]
-allowlist_externals = which
+isolated_build = true
 
-conda_env = environment.yml
-conda_setup_args=
-    --override-channels
-conda_install_args=
-    --override-channels
+[testenv]
+description = run the tests with pytest
+passenv = CI, GITHUB_*
+deps =
+    pytest
+
+    numpy
+    xarray
+    matplotlib
+    pandas
+    fair
+    netCDF4
+
+    oldest: numpy==1.21.*
+    oldest: xarray==0.20.*
+    oldest: matplotlib==3.5.*
+    oldest: pandas==1.3.*
+
+    latest: numpy
+    latest: xarray
+    latest: matplotlib
+    latest: pandas
 
 # skip_install = true
 
@@ -30,8 +46,7 @@ commands =
 [testenv:build_docs]
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
-extras = docs
+; extras = docs
 commands =
     pip install -r requirements.txt
-    pip install git+https://github.com/FixOurFood/agrifoodpy-data.git@importable
     sphinx-build -W -b html . _build/html


### PR DESCRIPTION
This PR addresses #86 by adding a configuration parser and a console script to execute agrifoodpy directly.

The script takes the input configuration file in yaml format as its only positional argument, with options to output results in json format, define initial and end nodes, setting skipped nodes, and printing node information.
It can also be configure to only define the pipeline and not execute it for debugging purposes.

