### PR TITLE
Python latest version and corrected  

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -3,26 +3,34 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
-  build-linux:
+  tests:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 5
+      fail-fast: false
+      matrix:
+        # Define the specific slices you want to test
+        include:
+          - python: '3.9'
+            toxenv: py39-oldest
+
+          - python: '3.9'
+            toxenv: py39-latest
+
+          - python: '3.14'
+            toxenv: py314-latest
+
+          - python: '3.14'
+            toxenv: build_docs
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+    - name: Set up Python ${{matrix.python}}
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
+        python-version: ${{matrix.python}}
+
     - name: Install dependencies
-      run: |
-        conda install -y python=3.9
-        conda env update --file environment.yml --name base
+      run: pip install tox
+
     - name: Test with tox
-      run: |
-        pip install tox
-        tox run
+      run: tox -e ${{matrix.toxenv}}

--- a/agrifoodpy/food/food.py
+++ b/agrifoodpy/food/food.py
@@ -71,13 +71,16 @@ def FoodSupply(
               "Year": _years}
 
     # find positions in output array to organize data
-    ii = [np.searchsorted(_items, items), np.searchsorted(_years, years)]
+    ii = [
+        np.atleast_1d(np.searchsorted(_items, items)),
+        np.atleast_1d(np.searchsorted(_years, years))
+    ]
     size = (len(_items), len(_years))
 
     # If regions and are provided, add the coordinate information
     if regions is not None:
         _regions = np.unique(regions)
-        ii.append(np.searchsorted(_regions, regions))
+        ii.append(np.atleast_1d(np.searchsorted(_regions, regions)))
         size = size + (len(_regions),)
         coords["Region"] = _regions
 

--- a/agrifoodpy/food/tests/test_food.py
+++ b/agrifoodpy/food/tests/test_food.py
@@ -474,11 +474,15 @@ def test_plot_bars():
        
 def test_plot_years():
     
-    da = xr.DataArray(np.arange(15).reshape(5,3),
-                        coords=[('Year', [2010, 2011, 2012, 2013, 2014]),
-                                ('Region', ['A', 'B', 'C'])],
-                        dims=['Year', 'Region'])
-    
+    years = [2019, 2010, 2011, 2012, 2013, 2014]
+    regions = ['A', 'B', 'C']
+
+    da = xr.DataArray(
+        np.arange(len(years)*len(regions)).reshape(len(years), len(regions)),
+        coords=[('Year', years),
+                ('Region', regions)],
+        dims=['Year', 'Region'])
+
     fbs = FoodElementSheet(da)
 
     # Test default call

--- a/agrifoodpy/land/land.py
+++ b/agrifoodpy/land/land.py
@@ -277,8 +277,8 @@ class LandDataArray:
 
         shape = map_left.shape
 
-        left_match = np.in1d(map_left, values_left).reshape(shape)
-        right_match = np.in1d(map_right, values_right).reshape(shape)
+        left_match = np.isin(map_left, values_left).reshape(shape)
+        right_match = np.isin(map_right, values_right).reshape(shape)
 
         category_match = map_left.where(left_match).where(right_match)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ myst-parser
 sphinx-gallery
 
 netcdf4
-git+https://github.com/FixOurFood/agrifoodpy-data.git@importable
+git+https://github.com/FixOurFood/agrifoodpy-data.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,35 @@
 [tox]
-requires =
-    tox-conda
-    setuptools
+; requires =
+    ; tox-conda
+    ; setuptools
 envlist =
-	py{39,310,311,312,313,314}
+	py{39,310,311,312,313,314}-{oldest,latest}
     build_docs
 
-[testenv]
-allowlist_externals = which
+isolated_build = true
 
-conda_env = environment.yml
-conda_setup_args=
-    --override-channels
-conda_install_args=
-    --override-channels
+[testenv]
+description = run the tests with pytest
+passenv = CI, GITHUB_*
+deps =
+    pytest
+    
+    numpy
+    xarray
+    matplotlib
+    pandas
+    fair
+    netCDF4
+
+    oldest: numpy==1.21.*
+    oldest: xarray==0.20.*
+    oldest: matplotlib==3.5.*
+    oldest: pandas==1.3.*
+
+    latest: numpy
+    latest: xarray
+    latest: matplotlib
+    latest: pandas
 
 # skip_install = true
 
@@ -33,5 +49,4 @@ description = invoke sphinx-build to build the HTML docs
 extras = docs
 commands =
     pip install -r requirements.txt
-    pip install git+https://github.com/FixOurFood/agrifoodpy-data.git@importable
     sphinx-build -W -b html . _build/html

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ requires =
     tox-conda
     setuptools
 envlist =
-	py{39,310}-test{,-latest,-oldest}
+	py{39,310,311,312,313,314}
     build_docs
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ description = run the tests with pytest
 passenv = CI, GITHUB_*
 deps =
     pytest
-    
+
     numpy
     xarray
     matplotlib
@@ -46,7 +46,7 @@ commands =
 [testenv:build_docs]
 changedir = docs
 description = invoke sphinx-build to build the HTML docs
-extras = docs
+; extras = docs
 commands =
     pip install -r requirements.txt
     sphinx-build -W -b html . _build/html


### PR DESCRIPTION
This PR sets the latest supported version of Python to 3.14
It also fixes an issue with the FoodSupply constructor, due to deprecated Numpy methods.
This also correctly configures tox to run with each version of Python between 3.9 and 3.14

