### PR TITLE
Changes to food scaling function

### DIFF
--- a/agrifoodpy/food/model.py
+++ b/agrifoodpy/food/model.py
@@ -4,7 +4,7 @@
 import xarray as xr
 import numpy as np
 import copy
-from ..pipeline import standalone
+from ..pipeline import standalone, pipeline_node
 from ..utils.dict_utils import get_dict, set_dict, item_parser
 import warnings
 
@@ -86,13 +86,10 @@ def balanced_scaling(
     if conversion_arr is not None:
         if isinstance(conversion_arr, xr.DataArray):
             conversion_arr = conversion_arr.where(
-                np.isfinite(conversion_arr), other=0)
-            if isinstance(conversion_arr, xr.DataArray):
-                conversion_arr = conversion_arr.where(
-                np.isfinite(conversion_arr), other=0)
-                if (conversion_arr == 0).any():
-                    warnings.warn("Conversion array contains zero values," \
-                    "which can lead to inaccurate scaling")
+                np.isfinite(conversion_arr), other=1)
+            if (conversion_arr == 0).any():
+                warnings.warn("Conversion array contains zero values, "
+                "which can lead to inaccurate scaling")
         else:
             conversion_arr = get_dict(datablock, conversion_arr)
 
@@ -385,3 +382,122 @@ def IDR(
     set_dict(datablock, out_key, idr)
 
     return datablock
+
+
+@pipeline_node(["fbs", "scale", "element", "threshold", "conversion_arr"])
+def scale_above_threshold(
+    fbs,
+    scale,
+    element,
+    threshold=0,
+    items=None,
+    origin=None,
+    add_to_origin=True,
+    elasticity=None,
+    fallback=None,
+    add_to_fallback=True,
+    conversion_arr=None,
+):
+    """Scales excess item quantities in a food balance sheet above a certain
+    threshold
+    
+    Parameters
+    ----------
+    fbs : xarray.Dataset
+        Input food balance sheet Dataset
+    scale : float, xarray.DataArray
+        Scaling value or array to apply to the excess above the threshold
+    element : string
+        Name of the DataArray to scale
+    threshold : float, xarray.DataArray, optional
+        Minimum value for the scaled element. Scaling of item quantities is
+        only applied to the excess above this threshold.
+    items : list, optional
+        List of items to scaled in the food balance sheet. If None, all items
+        are scaled.
+    origin : string, list, optional
+        Names of the DataArrays which will be used as source for the quantity
+        changes. Any change to the "element" DataArray will be reflected in
+        this DataArray
+    add_to_origin : bool, array, optional
+        Whether to add or subtract the difference from the respective origins
+    elasticity : float, array, optional
+        Relative fraction of the total difference to be assigned to each origin
+        element. Values are not normalized.
+    fallback : string
+        Name of the DataArray to use as fallback in case the origin quantities
+        fall below zero
+    add_to_fallback : bool, optional
+        Whether to add or subtract the difference below zero in the origin
+        DataArray to the fallback array.
+    conversion_arr : string, xarray.DataArray, tuple or float
+        Conversion array to pre-scale quantities. If provided, the input food
+        balance sheet is first converted using the conversion array, then the
+        scaling is applied, and finally the results are converted back to the
+        original units using the inverse of the conversion array.
+    """
+
+    if conversion_arr is not None:
+        if isinstance(conversion_arr, xr.DataArray):
+            conversion_arr = conversion_arr.where(
+                np.isfinite(conversion_arr), other=1)
+            if (conversion_arr == 0).any():
+                warnings.warn("Conversion array contains zero values," \
+                "which can lead to inaccurate scaling")
+    else:
+        conversion_arr = xr.ones_like(fbs[element])
+
+    if items is not None:
+        scaled_items = item_parser(fbs, items)
+        sel = {"Item": scaled_items}
+    else:
+        scaled_items = fbs.Item.values
+        sel = {}
+
+    # Calculate the maximum scale threshold that would reduce the sum of the
+    # element to the threshold, and apply the input scale relative to this
+    max_scale_threshold = (fbs[element].sum(dim="Item") - threshold) \
+        / fbs[element].sel(sel).sum(dim="Item")
+    
+    scale_threshold = max_scale_threshold * scale
+
+    if origin is not None and np.isscalar(origin):
+        origin = [origin]
+
+        if np.isscalar(add_to_origin):
+            add_to_origin = [add_to_origin]*len(origin)
+
+        if elasticity is None:
+            elasticity = [1/len(origin)]*len(origin)
+
+    # Scale input
+    if origin is None:
+        out = fbs.fbs.scale_element(
+            element=element,
+            scale=1-scale_threshold,
+            items=scaled_items
+        )
+
+    else:
+        out = fbs.fbs.scale_add(
+            element_in=element,
+            element_out=origin,
+            scale=1-scale_threshold,
+            items=scaled_items,
+            add=add_to_origin,
+            elasticity=elasticity
+        )
+
+    # If a fallback DataArray is defined, transfer the excess negative
+    # quantities to it
+    if fallback is not None:
+        for orig in origin:
+            dif = out[orig].where(out[orig] < 0).fillna(0)
+            out[fallback] -= np.where(add_to_fallback, 1, -1)*dif
+            out[orig] = out[orig].where(out[orig] > 0, 0)
+
+    # Convert back to original units if conversion array is provided
+    conversion_arr = conversion_arr.where(conversion_arr != 0, other=1)
+    out = out/conversion_arr
+
+    return out

--- a/agrifoodpy/food/model.py
+++ b/agrifoodpy/food/model.py
@@ -48,6 +48,9 @@ def balanced_scaling(
     constant : bool, optional
         If set to True, the sum of element remains constant by scaling the non
         selected items accordingly
+    padding_items : list, optional
+        List of items to use for scaling when 'constant' is True. If None, all
+        non-selected items are used for scaling.
     origin : string, list, optional
         Names of the DataArrays which will be used as source for the quantity
         changes. Any change to the "element" DataArray will be reflected in
@@ -89,14 +92,17 @@ def balanced_scaling(
                 np.isfinite(conversion_arr), other=1)
             if (conversion_arr == 0).any():
                 warnings.warn("Conversion array contains zero values, "
-                "which can lead to inaccurate scaling")
+                              "which can lead to inaccurate scaling")
+        elif isinstance(conversion_arr, (int, float)):
+            conversion_arr = xr.full_like(
+                data[element], fill_value=conversion_arr)
         else:
             conversion_arr = get_dict(datablock, conversion_arr)
 
-        data = data*conversion_arr
-
     else:
         conversion_arr = xr.ones_like(data[element])
+
+    data = data*conversion_arr
 
     out = copy.deepcopy(data)
 
@@ -149,7 +155,7 @@ def balanced_scaling(
         non_sel_scale = (data.sel(Item=non_sel_items)[element].sum(dim="Item")
                          - delta.sum(dim="Item")) \
             / data.sel(Item=non_sel_items)[element].sum(dim="Item")
-        
+
         # Identify where denominator is zero (non-finite scale)
         non_finite_mask = ~np.isfinite(non_sel_scale)
 
@@ -384,7 +390,7 @@ def IDR(
     return datablock
 
 
-@pipeline_node(["fbs", "scale", "element", "threshold", "conversion_arr"])
+@pipeline_node(["fbs", "conversion_arr"])
 def scale_above_threshold(
     fbs,
     scale,
@@ -444,8 +450,14 @@ def scale_above_threshold(
             if (conversion_arr == 0).any():
                 warnings.warn("Conversion array contains zero values," \
                 "which can lead to inaccurate scaling")
+
+        elif isinstance(conversion_arr, (int, float)):
+            conversion_arr = xr.full_like(
+                fbs[element], fill_value=conversion_arr)
     else:
         conversion_arr = xr.ones_like(fbs[element])
+
+    fbs = fbs*conversion_arr
 
     if items is not None:
         scaled_items = item_parser(fbs, items)

--- a/agrifoodpy/food/model.py
+++ b/agrifoodpy/food/model.py
@@ -490,7 +490,7 @@ def scale_above_threshold(
 
     # If a fallback DataArray is defined, transfer the excess negative
     # quantities to it
-    if fallback is not None:
+    if fallback is not None and origin is not None:
         for orig in origin:
             dif = out[orig].where(out[orig] < 0).fillna(0)
             out[fallback] -= np.where(add_to_fallback, 1, -1)*dif

--- a/agrifoodpy/food/model.py
+++ b/agrifoodpy/food/model.py
@@ -412,7 +412,9 @@ def scale_above_threshold(
     fbs : xarray.Dataset
         Input food balance sheet Dataset
     scale : float, xarray.DataArray
-        Scaling value or array to apply to the excess above the threshold
+        Scaling value or array to apply to the excess above the threshold. A
+        value of 1 means no scaling, while a value of 0 means scaling down to
+        the threshold.
     element : string
         Name of the DataArray to scale
     threshold : float, xarray.DataArray, optional
@@ -471,7 +473,7 @@ def scale_above_threshold(
     max_scale_threshold = (fbs[element].sum(dim="Item") - threshold) \
         / fbs[element].sel(sel).sum(dim="Item")
     
-    scale_threshold = max_scale_threshold * scale
+    scale_threshold = max_scale_threshold * (1 - scale)
 
     if origin is not None and np.isscalar(origin):
         origin = [origin]

--- a/agrifoodpy/food/model.py
+++ b/agrifoodpy/food/model.py
@@ -6,6 +6,7 @@ import numpy as np
 import copy
 from ..pipeline import standalone
 from ..utils.dict_utils import get_dict, set_dict, item_parser
+import warnings
 
 
 @standalone(input_keys=["fbs"], return_keys=["out_key"])
@@ -15,11 +16,13 @@ def balanced_scaling(
     element,
     items=None,
     constant=False,
+    padding_items=None,
     origin=None,
     add_to_origin=True,
     elasticity=None,
     fallback=None,
     add_to_fallback=True,
+    conversion_arr=None,
     out_key=None,
     datablock=None
 ):
@@ -60,6 +63,11 @@ def balanced_scaling(
     add_to_fallback : bool, optional
         Whether to add or subtract the difference below zero in the origin
         DataArray to the fallback array.
+    conversion_arr : string, xarray.DataArray, tuple or float
+        Conversion array to pre-scale quantities. If provided, the input food
+        balance sheet is first converted using the conversion array, then the
+        scaling is applied, and finally the results are converted back to the
+        original units using the inverse of the conversion array.
     out_key : string, tuple
         Output datablock path to write results to. If not given, input path is
         overwritten
@@ -74,6 +82,25 @@ def balanced_scaling(
 
     # Pepare inputs
     data = copy.deepcopy(get_dict(datablock, fbs))
+
+    if conversion_arr is not None:
+        if isinstance(conversion_arr, xr.DataArray):
+            conversion_arr = conversion_arr.where(
+                np.isfinite(conversion_arr), other=0)
+            if isinstance(conversion_arr, xr.DataArray):
+                conversion_arr = conversion_arr.where(
+                np.isfinite(conversion_arr), other=0)
+                if (conversion_arr == 0).any():
+                    warnings.warn("Conversion array contains zero values," \
+                    "which can lead to inaccurate scaling")
+        else:
+            conversion_arr = get_dict(datablock, conversion_arr)
+
+        data = data*conversion_arr
+
+    else:
+        conversion_arr = xr.ones_like(data[element])
+
     out = copy.deepcopy(data)
 
     if out_key is None:
@@ -118,19 +145,25 @@ def balanced_scaling(
         delta = out[element] - data[element]
 
         # Identify non selected items and scaling
-        non_sel_items = np.setdiff1d(data.Item.values, scaled_items)
+        if padding_items is None:
+            non_sel_items = np.setdiff1d(data.Item.values, scaled_items)
+        else:
+            non_sel_items = item_parser(data, padding_items)
         non_sel_scale = (data.sel(Item=non_sel_items)[element].sum(dim="Item")
                          - delta.sum(dim="Item")) \
             / data.sel(Item=non_sel_items)[element].sum(dim="Item")
+        
+        # Identify where denominator is zero (non-finite scale)
+        non_finite_mask = ~np.isfinite(non_sel_scale)
 
-        # Make sure no scaling occurs on inf and nan
-        non_sel_scale = non_sel_scale.where(
+        # Use multiplicative scaling where finite, no-op (scale=1) where not
+        non_sel_scale_finite = non_sel_scale.where(
             np.isfinite(non_sel_scale)).fillna(1.0)
 
         if origin is None:
             out = out.fbs.scale_element(
                 element=element,
-                scale=non_sel_scale,
+                scale=non_sel_scale_finite,
                 items=non_sel_items
             )
 
@@ -138,11 +171,31 @@ def balanced_scaling(
             out = out.fbs.scale_add(
                 element_in=element,
                 element_out=origin,
-                scale=non_sel_scale,
+                scale=non_sel_scale_finite,
                 items=non_sel_items,
                 add=add_to_origin,
                 elasticity=elasticity
             )
+
+        # For non-finite cases (zero original quantity), add delta directly
+        # distributed equally across non_sel_items
+        if bool(non_finite_mask.any()):
+            n_non_sel = len(non_sel_items)
+            per_item_additive = (
+                (-delta.sum(dim="Item")).where(non_finite_mask).fillna(0)
+                / n_non_sel
+            )
+
+            sel = {"Item": non_sel_items}
+
+            out[element].loc[sel] = out[element].loc[sel] + per_item_additive
+            if origin is not None:
+                for elmnt, add_el, elast in zip(origin, add_to_origin, elasticity):
+                    out[elmnt].loc[sel] = (
+                        out[elmnt].loc[sel]
+                        + np.where(add_el, -1, 1) *
+                        (-per_item_additive) * elast
+                    )
 
     # If a fallback DataArray is defined, transfer the excess negative
     # quantities to it
@@ -151,6 +204,10 @@ def balanced_scaling(
             dif = out[orig].where(out[orig] < 0).fillna(0)
             out[fallback] -= np.where(add_to_fallback, 1, -1)*dif
             out[orig] = out[orig].where(out[orig] > 0, 0)
+
+    # Convert back to original units if conversion array is provided
+    conversion_arr = conversion_arr.where(conversion_arr != 0, other=1)
+    out = out/conversion_arr
 
     set_dict(datablock, out_key, out)
 

--- a/agrifoodpy/food/tests/test_model.py
+++ b/agrifoodpy/food/tests/test_model.py
@@ -388,3 +388,198 @@ def test_fbs_convert():
     )
 
     xr.testing.assert_allclose(result_factor, ex_result_factor)
+
+
+def test_scale_above_threshold():
+
+    from agrifoodpy.food.model import scale_above_threshold
+    from agrifoodpy.pipeline import Pipeline
+
+    items = ["Beef", "Apples"]
+    years = [2020, 2021]
+
+    fbs = xr.Dataset(
+        data_vars=dict(
+            imports=(["Year", "Item"], [[10., 20.], [30., 40.]]),
+            production=(["Year", "Item"], [[50., 60.], [70., 80.]]),
+            exports=(["Year", "Item"], [[5., 10.], [15., 20.]]),
+            food=(["Year", "Item"], [[55., 70.], [85., 100.]])
+        ),
+
+        coords=dict(Item=("Item", items), Year=("Year", years))
+    )
+
+    # Test basic result with unity scaling factor
+    result_basic = scale_above_threshold(
+        fbs,
+        scale=1.0,
+        element="food",
+    )
+
+    xr.testing.assert_allclose(result_basic, fbs)
+
+    # Test basic in a pipeline
+    test_pipeline = Pipeline({"data": fbs})
+
+    test_pipeline.add_node(
+        scale_above_threshold,
+        {
+            "fbs": "data",
+            "scale": 1.0,
+            "element": "food",
+        })
+
+    test_pipeline.run()
+
+    assert "scale_above_threshold" in test_pipeline.datablock
+    xr.testing.assert_equal(
+        test_pipeline.datablock["scale_above_threshold"], fbs)
+
+    # Test result with positive scaling factor less than 1
+    result_scaled = scale_above_threshold(
+        fbs,
+        scale=0.5,
+        element="food",
+        threshold=60.0
+    )
+    ex_result = (fbs["food"].sum(dim="Item") - 60.0) * 0.5 + 60.0
+    
+    xr.testing.assert_allclose(
+        result_scaled["food"].sum(dim="Item"),
+        ex_result)
+
+    # Test result with positive scaling factor greater than 1
+    result_scaled = scale_above_threshold(
+        fbs,
+        scale=2.0,
+        element="food",
+        threshold=60.0
+    )
+    ex_result = (fbs["food"].sum(dim="Item") - 60.0) * 2.0 + 60.0
+
+    xr.testing.assert_allclose(result_scaled["food"].sum(dim="Item"),
+                               ex_result)
+
+    # Test result with zero scaling factor
+    result_zero = scale_above_threshold(
+        fbs,
+        scale=0.0,
+        element="food",
+        threshold=60.0
+    )
+    ex_result_zero = (fbs["food"].sum(dim="Item") - 60.0) * 0.0 + 60.0
+    xr.testing.assert_allclose(
+        result_zero["food"].sum(dim="Item"),
+        ex_result_zero)
+
+    # Test result with array scale
+    scale_arr = xr.DataArray(
+        [0.1, 0.5],
+        dims=["Year"],
+        coords={"Year": years},
+    )
+
+    result_array_scale = scale_above_threshold(
+        fbs,
+        scale=scale_arr,
+        element="food",
+        threshold=60.0
+    )
+
+    ex_result_arr = (fbs["food"].sum(dim="Item") - 60.0) * scale_arr + 60.0
+    xr.testing.assert_allclose(
+        result_array_scale["food"].sum(dim="Item"),
+        ex_result_arr)
+
+    # Test with selected items
+    result_array_items = scale_above_threshold(
+        fbs,
+        scale=0.0,
+        element="food",
+        threshold=60.0,
+        items="Beef"
+    )
+
+    ex_result_sel = (fbs["food"].sum(dim="Item") - 60.0) * 0.0 + 60.0
+
+    xr.testing.assert_allclose(
+        result_array_items["food"].sum(dim="Item"),
+        ex_result_sel)
+
+    # Test with array threshold
+    threshold_arr = xr.DataArray(
+        [50.0, 70.0],
+        dims=["Year"],
+        coords={"Year": years},
+    )
+
+    result_array_threshold = scale_above_threshold(
+        fbs,
+        scale=0.5,
+        element="food",
+        threshold=threshold_arr
+    )
+
+    ex_result_threshold = (fbs["food"].sum(dim="Item") - threshold_arr) * 0.5 \
+        + threshold_arr
+
+    xr.testing.assert_allclose(
+        result_array_threshold["food"].sum(dim="Item"),
+        ex_result_threshold)
+
+    # Test with origin
+    result_origin = scale_above_threshold(
+        fbs,
+        scale=0.5,
+        element="food",
+        threshold=60.0,
+        origin="production"
+    )
+
+    excess = fbs["food"] - result_origin["food"]
+    ex_result_origin = fbs["production"] - excess
+    xr.testing.assert_allclose(
+        result_origin["production"], ex_result_origin)
+    
+    # Test with multiple origins and separate elasticity values
+    result_elasticity = scale_above_threshold(
+        fbs,
+        scale=0.5,
+        element="food",
+        threshold=60.0,
+        origin=["production", "imports"],
+        elasticity=[0.8, 0.2]
+    )
+
+    excess = fbs["food"] - result_elasticity["food"]
+    ex_result_prod = fbs["production"] - excess * 0.8
+    ex_result_imports = fbs["imports"] - excess * 0.2
+
+    xr.testing.assert_allclose(
+        result_elasticity["production"], ex_result_prod)
+    xr.testing.assert_allclose(
+        result_elasticity["imports"], ex_result_imports)
+    
+    # Test with conversion array
+    conversion_arr = xr.DataArray(
+        [1.0, 2.0],
+        dims=["Item"],
+        coords={"Item": items})
+    
+    result_conversion = scale_above_threshold(
+        fbs,
+        scale=0.5,
+        element="food",
+        threshold=60.0,
+        conversion_arr=conversion_arr
+    )
+
+    conv_arr = fbs * conversion_arr
+    ex_result_conv = (conv_arr["food"].sum(dim="Item") - 60.0) * 0.5 + 60.0
+
+    xr.testing.assert_allclose(
+        (result_conversion["food"]*conversion_arr).sum(dim="Item"),
+        ex_result_conv)
+
+
+    

--- a/agrifoodpy/food/tests/test_model.py
+++ b/agrifoodpy/food/tests/test_model.py
@@ -30,6 +30,27 @@ def test_balanced_scaling():
 
     xr.testing.assert_equal(result_basic, fbs)
 
+    # Test without year dimension
+    fbs_no_year = fbs.isel(Year=0).drop("Year")
+
+    result_no_year = balanced_scaling(
+        fbs_no_year,
+        scale=2.0,
+        element="food"
+    )
+
+    ex_result_no_year = xr.Dataset(
+        data_vars=dict(
+            imports=(["Item"], [10., 20.]),
+            production=(["Item"], [50., 60.]),
+            exports=(["Item"], [5., 10.]),
+            food=(["Item"], [110., 140.])
+            ),
+        coords=dict(Item=("Item", items))
+    )
+
+    xr.testing.assert_equal(result_no_year, ex_result_no_year)
+
     # Test result with scalar scaling factor
     result_scalar = balanced_scaling(
         fbs,
@@ -224,7 +245,6 @@ def test_balanced_scaling():
             imports=(["Year", "Item"], [[10., 20.], [30., 40.]]),
             production=(["Year", "Item"], [[50., 60.], [70., 80.]]),
             exports=(["Year", "Item"], [[5., 10.], [15., 20.]]),
-            # food=(["Year", "Item"], [[55., 70.], [85., 100.]])
             food=(["Year", "Item"], [[55., 70.], [170., 100.]])
             ),
 

--- a/agrifoodpy/food/tests/test_model.py
+++ b/agrifoodpy/food/tests/test_model.py
@@ -31,7 +31,7 @@ def test_balanced_scaling():
     xr.testing.assert_equal(result_basic, fbs)
 
     # Test without year dimension
-    fbs_no_year = fbs.isel(Year=0).drop("Year")
+    fbs_no_year = fbs.isel(Year=0).drop_vars("Year")
 
     result_no_year = balanced_scaling(
         fbs_no_year,


### PR DESCRIPTION
## Description

This pull requests partially addresses #93 by extending the functionality of `balanced_scaling`.

## To-do list
- [x] Add a threshold value or cap scaling to implement the `food_waste` functionality
- [x] Allow scaling based on converted values of the input food balance sheet array
- [x] Allow multiple items lists and item/item group dependent scaling  
- [x] Automatically create non-existing padding items

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/FixOurFood/AgriFoodPy/blob/main/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
