### PR TITLE
added fix for default parameters

### DIFF
--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -354,7 +354,8 @@ def pipeline_node(input_keys=None):
                 raise TypeError(
                     f"Invalid arguments for function {func.__name__}."
                 ) from e
-            
+
+            explicit_args = set(bound.arguments.keys())
             bound.apply_defaults()
 
             if datablock is None:
@@ -362,8 +363,9 @@ def pipeline_node(input_keys=None):
             
             else:
                 for key in input_keys:
-                    bound.arguments[key] = get_dict(datablock,
-                                                    bound.arguments[key])
+                    if key in explicit_args:
+                        bound.arguments[key] = get_dict(datablock,
+                                                        bound.arguments[key])
                 result = func(*bound.args, **bound.kwargs)
 
                 set_dict(datablock, return_key, result)

--- a/agrifoodpy/pipeline/tests/test_pipeline.py
+++ b/agrifoodpy/pipeline/tests/test_pipeline.py
@@ -317,6 +317,37 @@ def test_pipeline_node_decorator():
     assert return_constant.__name__ in test_pipeline_no_input.datablock
     assert test_pipeline_no_input.datablock[return_constant.__name__] == 42
 
+    # Test decorated function with default parameter values and called with
+    # missing parameters
+    test_pipeline_default_missing = Pipeline({'input_value': 5})
+    @pipeline_node(['input_value', 'factor'])
+    def scale_with_default(input_value, factor=3):
+        return input_value * factor
+    
+    test_pipeline_default_missing.add_node(
+        scale_with_default,
+        params={'input_value': 'input_value'}
+        )
+    
+    test_pipeline_default_missing.run()
+    assert scale_with_default(test_pipeline_default_missing.datablock['input_value']) == 15
+    assert test_pipeline_default_missing.datablock[scale_with_default.__name__] == 15
+
+    # Test decorated function with default parameter values and called with all parameters
+    test_pipeline_default_all = Pipeline({'input_value': 5, 'factor': 4})
+    @pipeline_node(['input_value', 'factor'])
+    def scale_with_default_all(input_value=2, factor=3):
+        return input_value * factor
+    
+    test_pipeline_default_all.add_node(
+        scale_with_default_all,
+        params={'input_value': 'input_value', 'factor': 'factor'}
+        )
+    
+    test_pipeline_default_all.run()
+    assert scale_with_default_all(test_pipeline_default_all.datablock['input_value'], factor=4) == 20
+    assert test_pipeline_default_all.datablock[scale_with_default_all.__name__] == 20
+
     # Test decorated function with reserved parameter names
     with pytest.raises(ValueError, match="reserved parameter names.*datablock"):
         @pipeline_node(['x'])


### PR DESCRIPTION
## Description
This PR fixes a bug with pipeline-ready decorated functions where registered parameters with default values fail to receive default values when not explicitly defined, raising a KeyError value instead


## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/FixOurFood/AgriFoodPy/blob/main/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
