### PR TITLE
added land conversion methods

### DIFF
--- a/agrifoodpy/land/land.py
+++ b/agrifoodpy/land/land.py
@@ -6,7 +6,7 @@ import xarray as xr
 import matplotlib.pyplot as plt
 from matplotlib import colors as mcolors
 import matplotlib.patches as mpatches
-
+from warnings import warn
 
 @xr.register_dataarray_accessor("land")
 class LandDataArray:
@@ -24,8 +24,9 @@ class LandDataArray:
 
         if "x" not in obj.dims or "y" not in obj.dims:
             raise AttributeError("Land array must have 'x' and 'y' dimensions")
+        
 
-    def plot(self, ax=None, class_coord=None, colors=None, labels=None,
+    def plot(self, ax=None, category_dim=None, colors=None, labels=None,
              **kwargs):
         """Plot a LandDataArray
 
@@ -39,9 +40,9 @@ class LandDataArray:
         ----------
         ax : matplotlib.pyplot.Artist
             Axes on which to draw the plot
-        class_coord : string
-            Name of the coordinate to use as land classes. If not provided, the
-            first non spatial coordinate is used.
+        category_dim : string
+            Name of the dimension to use as land category. If not provided, the
+            first non spatial dimension is used.
         colors : list of strings
             Dictionary of colors to use for each land class. If not provided,
             the default matplotlib colour map is used.
@@ -57,6 +58,14 @@ class LandDataArray:
         ax : matplotlib axes instance
         """
 
+        if "class_coord" in kwargs:
+            warn("class_coord is deprecated as a keyword argument. "
+                 "Please use category_dim instead.",
+                 DeprecationWarning,
+                 stacklevel=2)
+
+            category_dim = kwargs.pop("class_coord")
+
         map = self._obj
 
         if ax is None:
@@ -67,7 +76,7 @@ class LandDataArray:
         if len(extra_coords) >= 1:
             if labels is None:
                 labels = map[extra_coords[0]].values
-            map = self.dominant_class(class_coord=class_coord)
+            map = self.dominant_class(category_dim=category_dim)
         else:
             labels = np.unique(map.values)
 
@@ -88,6 +97,8 @@ class LandDataArray:
         xmin, xmax = map.x.values[[0, -1]]
         ymin, ymax = map.y.values[[0, -1]]
 
+        print(map)
+
         ax.imshow(map, interpolation="none", origin="lower",
                   extent=[xmin-dx_low,
                           xmax+dx_high,
@@ -102,11 +113,22 @@ class LandDataArray:
         ax.legend(handles=patches, loc="best")
 
         return ax
+    
 
-    def area_by_type(
+    def area_by_type(self, values=None, dim=None):
+        warn("The area_by_type method is deprecated and will be removed in a "
+        "future version. Use area_by_category instead.",
+        DeprecationWarning,
+        stacklevel=2)
+
+        return self.area_by_category(values=values, dim=dim)
+    
+
+    def area_by_category(
         self,
-        values=None,
-        dim=None
+        categories=None,
+        dim=None,
+        **kwargs
     ):
         """Area per map category in a LandDataArray
 
@@ -116,8 +138,8 @@ class LandDataArray:
         Parameters
         ----------
         values : int, array
-            List of category types to return the total area for. If not set,
-            the function returns areas for all values found on the map,
+            List of categories to return the total area for. If not set,
+            the function returns areas for all categories found on the map,
             excluding nan values.
         dim : string
             Name to assign to the categories coordinate. If not set, the input
@@ -130,33 +152,43 @@ class LandDataArray:
             combination.
         """
 
+        if "values" in kwargs:
+            warn("values is deprecated as a keyword argument. "
+                 "Please use categories instead.",
+                 DeprecationWarning,
+                 stacklevel=2)
+
+            categories = kwargs.pop("values")
+
         map = self._obj
         ones = xr.ones_like(map)
 
         if dim is None:
             dim = map.name
 
-        if values is None:
-            values = np.unique(map)
+        if categories is None:
+            categories = np.unique(map)
         else:
-            values = np.array(values)
+            categories = np.array(categories)
 
         # Prevent nan values from being counted
-        nan_indices = np.isnan(values)
-        values = values[~nan_indices]
-        area = [ones.where(map == value).sum() for value in values]
+        nan_indices = np.isnan(categories)
+        categories = categories[~nan_indices]
+        area = [ones.where(map == value).sum() for value in categories]
 
-        area_arr = xr.DataArray(area, dims=dim, coords={dim: values})
+        area_arr = xr.DataArray(area, dims=dim, coords={dim: categories})
 
         return area_arr
+
 
     def area_overlap(
         self,
         map_right,
-        values_left=None,
-        values_right=None,
+        categories_left=None,
+        categories_right=None,
         dim_left=None,
-        dim_right=None
+        dim_right=None,
+        **kwargs
     ):
         """Area overlap of selected categories between two maps
 
@@ -168,14 +200,14 @@ class LandDataArray:
         ----------
         map_right : xarray.DataArray
             LandDataArray style DataArray to compare overlapping areas with
-        values_left
-            List of category types from the left map to return the total area
+        categories_left
+            List of land categories from the left map to return the total area
             overlaps for.
-            If not set, all category types are used, except nan values.
-        values_right : int, array
-            List of category types from the right map to return the total area
+            If not set, all categories are used, except nan values.
+        categories_right : int, array
+            List of land categories from the right map to return the total area
             overlaps for.
-            If not set, all category types are used, except nan values.
+            If not set, all categories are used, except nan values.
         dim_left : string
             Names to assign to the category coordinates on the output
             DataArray.
@@ -191,6 +223,25 @@ class LandDataArray:
             Array with the corresponding areas for each category type
 
         """
+
+        if "values_left" in kwargs:
+            warn("values_left is deprecated and will be removed in a future "
+                 "version. Please use categories_left instead.",
+                 DeprecationWarning,
+                 stacklevel=2)
+            
+            categories_left = kwargs.pop("values_left")
+                
+        if "values_right" in kwargs:
+            warn("values_right is deprecated and will be removed in a future "
+                 "version. Please use categories_right instead.",
+                 DeprecationWarning,
+                 stacklevel=2)
+            
+            categories_right = kwargs.pop("values_right")
+                
+
+
         map_left = self._obj
 
         # Check that both maps have the same dimensions and coordinates.
@@ -203,40 +254,42 @@ class LandDataArray:
         if dim_right is None:
             dim_right = map_right.name
 
-        if values_left is None:
-            values_left = np.unique(map_left)
+        if categories_left is None:
+            categories_left = np.unique(map_left)
         else:
-            values_left = np.array(values_left)
+            categories_left = np.array(categories_left)
 
-        if values_right is None:
-            values_right = np.unique(map_right)
+        if categories_right is None:
+            categories_right = np.unique(map_right)
         else:
-            values_right = np.array(values_right)
+            categories_right = np.array(categories_right)
 
         # Prevent nan values from being counted
-        nan_indices_left = np.isnan(values_left)
-        nan_indices_right = np.isnan(values_right)
+        nan_indices_left = np.isnan(categories_left)
+        nan_indices_right = np.isnan(categories_right)
 
-        values_left = values_left[~nan_indices_left]
-        values_right = values_right[~nan_indices_right]
+        categories_left = categories_left[~nan_indices_left]
+        categories_right = categories_right[~nan_indices_right]
 
         ones = xr.ones_like(map_left)
         area = [[ones.where(map_left == vl).where(map_right == vr).sum().values
-                 for vr in values_right] for vl in values_left]
+                 for vr in categories_right] for vl in categories_left]
 
         area_arr = xr.DataArray(area,
                                 dims=[dim_left, dim_right],
-                                coords={dim_left: values_left,
-                                        dim_right: values_right})
+                                coords={dim_left: categories_left,
+                                        dim_right: categories_right})
 
         return area_arr
+    
 
     def category_match(
         self,
         map_right,
-        values_left=None,
-        values_right=None,
-        join="left"
+        categories_left=None,
+        categories_right=None,
+        join="left",
+        **kwargs
     ):
         """Returns a land Dataarray with values where a selected overlap occurs
         between categories from two maps. This returns the values from the left
@@ -259,42 +312,77 @@ class LandDataArray:
             Land DataArray with values from the left map where overlap occurs.
             All other positions are assign a nan value.
         """
+
+        if "values_left" in kwargs:
+            warn("values_left is deprecated and will be removed in a future "
+                 "version. Please use categories_left instead.",
+                 DeprecationWarning,
+                 stacklevel=2)
+            
+            categories_left = kwargs.pop("values_left")
+                
+        if "values_right" in kwargs:
+            warn("values_right is deprecated and will be removed in a future "
+                 "version. Please use categories_right instead.",
+                 DeprecationWarning,
+                 stacklevel=2)
+            
+            categories_right = kwargs.pop("values_right")
+
         map_left = self._obj
 
         # Check input values
-        if values_left is None:
-            values_left = np.unique(map_left)
+        if categories_left is None:
+            categories_left = np.unique(map_left)
         else:
-            values_left = np.array(values_left)
+            categories_left = np.array(categories_left)
 
-        if values_right is None:
-            values_right = np.unique(map_right)
+        if categories_right is None:
+            categories_right = np.unique(map_right)
         else:
-            values_right = np.array(values_right)
+            categories_right = np.array(categories_right)
 
         # Align maps to the left so they have the same dimensions
         map_left, map_right = xr.align(map_left, map_right, join=join)
 
         shape = map_left.shape
 
-        left_match = np.isin(map_left, values_left).reshape(shape)
-        right_match = np.isin(map_right, values_right).reshape(shape)
+        left_match = np.isin(map_left, categories_left).reshape(shape)
+        right_match = np.isin(map_right, categories_right).reshape(shape)
 
         category_match = map_left.where(left_match).where(right_match)
 
         return category_match
 
+
     def dominant_class(
         self,
         class_coord=None,
-        return_index=False
+        return_index=False,
+        **kwargs
+    ):
+        warn("The dominant_class method is deprecated and will be removed in" \
+        " a future version. Please use dominant_category instead.",
+        DeprecationWarning,
+        stacklevel=2)
+
+        return self.dominant_category(
+            category_dim=class_coord,
+            return_index=return_index,
+            kwargs=kwargs)
+
+    def dominant_category(
+        self,
+        category_dim=None,
+        return_index=False,
+        **kwargs
     ):
         """Returns a land DataArray with the dominant land class for each
         pixel.
 
         Parameters
         ----------
-        class_coord : string
+        category_dim : string
             Name of the land class coordinate. If not set, the first coordinate
             is used.
         return_index : bool
@@ -307,15 +395,129 @@ class LandDataArray:
             Land DataArray with the dominant land class for each pixel.
         """
 
+        if "class_coord" in kwargs:
+            warn("class_coord is deprecated as a keyword argument. "
+                 "Please use category_dim instead.",
+                 DeprecationWarning,
+                 stacklevel=2)
+            
+            category_dim = kwargs.pop("class_coord")
+
         map = self._obj
 
-        if class_coord is None:
-            class_coord = [dim for dim in map.dims if dim not in ["x", "y"]][0]
+        if category_dim is None:
+            category_dim = [dim for dim in map.dims if dim not in ["x", "y"]][0]
 
         if return_index:
-            len_class = len(map[class_coord].values)
-            map = map.assign_coords({class_coord: np.arange(len_class)})
+            len_class = len(map[category_dim].values)
+            map = map.assign_coords({category_dim: np.arange(len_class)})
 
-        map = map.idxmax(dim=class_coord, skipna=True)
+        map = map.idxmax(dim=category_dim, skipna=True)
 
         return map
+
+
+    def add_category(
+        self,
+        category,
+        category_value=0,
+        mask=None,
+        category_dim=None,
+    ):
+        """Add a new land category to a LandDataArray
+
+        Parameters
+        ----------
+        category : string, list of strings
+            Name of the land class coordinate to add.
+            Cannot contain values already present in the LandDataArray,
+            or duplicated within the input list.
+        category_value : int, xarray.DataArray
+            Value of the new land class to add. If an array is provided, it
+            must have the same shape as the spatial dimensions of the
+            LandDataArray.
+        mask : xarray.DataArray
+            Boolean DataArray with the same spatial dimensions as the
+            LandDataArray indicating where to add the new category.
+            If not provided, the new category is added to all pixels.
+        category_dim : string
+            Name of the land class dimension. If not set, the first non spatial
+            dimension is used.
+
+        Returns
+        -------
+        xarray.DataArray
+            Land DataArray with the new land category added.
+        """
+
+        map = self._obj
+
+        # Use the first non spatial dimension if category dimension not provided
+        if category_dim is None:
+            category_dim = [d for d in map.dims if d not in ["x", "y", "Year"]][0]
+
+
+        # Validate the mask input
+        if mask is None:
+            mask = xr.ones_like(map.isel({category_dim:0}), dtype=bool)
+        else:
+            if not isinstance(mask, xr.DataArray):
+                raise TypeError("'mask' must be an xarray.DataArray")
+
+            if set(mask.dims) != {"x", "y"}:
+                raise ValueError("'mask' must have exactly the spatial " \
+                "dimensions 'x' and 'y'")
+
+            spatial_template = map.isel({category_dim: 0})
+            try:
+                xr.align(spatial_template, mask, join="exact")
+            except ValueError as err:
+                raise ValueError(
+                    "'mask' must be aligned with the map spatial coordinates "
+                    "'x' and 'y'"
+                ) from err
+            
+        # Validate the category_value input
+        if isinstance(category_value, (int, float)):
+            category_value = xr.ones_like(
+                map.isel({category_dim:0}))*category_value
+            
+        elif isinstance(category_value, xr.DataArray):
+            if set(category_value.dims) != {"x", "y"}:
+                raise ValueError("'category_value' must have exactly the " \
+                "spatial dimensions 'x' and 'y'")
+            
+            spatial_template = map.isel({category_dim: 0})
+            try:
+                xr.align(spatial_template, category_value, join="exact")
+            except ValueError as err:
+                raise ValueError(
+                    "'category_value' must be aligned with the map spatial " \
+                    "coordinates 'x' and 'y'"
+                ) from err
+        else:
+            raise TypeError("'category_value' must be either a scalar or an " \
+            "xarray.DataArray with 'x' and 'y' dimensions")
+
+        new_map = map.copy()
+
+        if isinstance(category, str):
+            category = [category]
+
+        # Check that there are no duplicate category values in the input list
+        if len(category) != len(set(category)):
+            raise ValueError("Duplicate category values found in input list")
+
+        # Check that the new category does not already exist in the map
+        for cat in category:
+            if cat in map[category_dim].values:
+                raise ValueError(f"Category {cat} already exists in the"
+                                 " LandDataArray")
+            
+            # Append new category values to the map
+            new_class = xr.ones_like(map.isel({category_dim:0}))*category_value
+            new_class = new_class.where(mask)
+            new_class[category_dim] = cat
+            new_map = xr.concat([new_map, new_class], dim=category_dim)
+
+        return new_map

--- a/agrifoodpy/land/land.py
+++ b/agrifoodpy/land/land.py
@@ -76,7 +76,7 @@ class LandDataArray:
         if len(extra_coords) >= 1:
             if labels is None:
                 labels = map[extra_coords[0]].values
-            map = self.dominant_class(category_dim=category_dim)
+            map = self.dominant_category(category_dim=category_dim)
         else:
             labels = np.unique(map.values)
 
@@ -96,8 +96,6 @@ class LandDataArray:
 
         xmin, xmax = map.x.values[[0, -1]]
         ymin, ymax = map.y.values[[0, -1]]
-
-        print(map)
 
         ax.imshow(map, interpolation="none", origin="lower",
                   extent=[xmin-dx_low,
@@ -121,14 +119,13 @@ class LandDataArray:
         DeprecationWarning,
         stacklevel=2)
 
-        return self.area_by_category(values=values, dim=dim)
+        return self.area_by_category(categories=values, dim=dim)
     
 
     def area_by_category(
         self,
         categories=None,
         dim=None,
-        **kwargs
     ):
         """Area per map category in a LandDataArray
 
@@ -137,7 +134,7 @@ class LandDataArray:
 
         Parameters
         ----------
-        values : int, array
+        cateogries : int, array
             List of categories to return the total area for. If not set,
             the function returns areas for all categories found on the map,
             excluding nan values.
@@ -151,14 +148,6 @@ class LandDataArray:
             Array with the corresponding areas overlaps for each category
             combination.
         """
-
-        if "values" in kwargs:
-            warn("values is deprecated as a keyword argument. "
-                 "Please use categories instead.",
-                 DeprecationWarning,
-                 stacklevel=2)
-
-            categories = kwargs.pop("values")
 
         map = self._obj
         ones = xr.ones_like(map)
@@ -369,7 +358,7 @@ class LandDataArray:
         return self.dominant_category(
             category_dim=class_coord,
             return_index=return_index,
-            kwargs=kwargs)
+            **kwargs)
 
     def dominant_category(
         self,
@@ -406,7 +395,7 @@ class LandDataArray:
         map = self._obj
 
         if category_dim is None:
-            category_dim = [dim for dim in map.dims if dim not in ["x", "y"]][0]
+            category_dim = [dim for dim in map.dims if dim not in ["Year", "x", "y"]][0]
 
         if return_index:
             len_class = len(map[category_dim].values)

--- a/agrifoodpy/land/land.py
+++ b/agrifoodpy/land/land.py
@@ -453,9 +453,11 @@ class LandDataArray:
             if not isinstance(mask, xr.DataArray):
                 raise TypeError("'mask' must be an xarray.DataArray")
 
-            if set(mask.dims) != {"x", "y"}:
-                raise ValueError("'mask' must have exactly the spatial " \
-                "dimensions 'x' and 'y'")
+            if set(mask.dims) not in ({"x", "y"}, {"x", "y", "Year"}):
+                raise ValueError(
+                    "'mask' must have spatial dimensions 'x' and 'y', with "
+                    "an optional 'Year' dimension"
+                )
 
             spatial_template = map.isel({category_dim: 0})
             try:
@@ -472,9 +474,11 @@ class LandDataArray:
                 map.isel({category_dim:0}))*category_value
             
         elif isinstance(category_value, xr.DataArray):
-            if set(category_value.dims) != {"x", "y"}:
-                raise ValueError("'category_value' must have exactly the " \
-                "spatial dimensions 'x' and 'y'")
+            if set(category_value.dims) not in ({"x", "y"}, {"x", "y", "Year"}):
+                raise ValueError(
+                    "'category_value' must have spatial dimensions 'x' and "
+                    "'y', with an optional 'Year' dimension"
+                )
             
             spatial_template = map.isel({category_dim: 0})
             try:
@@ -486,7 +490,8 @@ class LandDataArray:
                 ) from err
         else:
             raise TypeError("'category_value' must be either a scalar or an " \
-            "xarray.DataArray with 'x' and 'y' dimensions")
+            "xarray.DataArray with 'x' and 'y' dimensions, and an optional "
+            "'Year' dimension")
 
         new_map = map.copy()
 

--- a/agrifoodpy/land/model.py
+++ b/agrifoodpy/land/model.py
@@ -1,10 +1,12 @@
 """ Module for land intervention models
-
 """
 
 import numpy as np
+import xarray as xr
 from ..land.land import LandDataArray
-
+from ..pipeline import pipeline_node
+from ..utils.dict_utils import item_parser 
+import warnings
 
 def land_sequestration(
     land_da,
@@ -66,7 +68,7 @@ def land_sequestration(
     if not (fraction >= 0).all() and (fraction <= 1).all():
         raise ValueError("Input fraction values must be between 0 and 1")
 
-    pixel_count_category = land_da.land.area_by_type(values=use_id)
+    pixel_count_category = land_da.land.area_by_category(categories=use_id)
 
     # area in hectares
     area_category = pixel_count_category * ha_per_pixel
@@ -97,3 +99,244 @@ def land_sequestration(
     total_seq = area.sum() * scale * max_seq
 
     return total_seq
+
+@pipeline_node("land")
+def scale_land(
+    land,
+    origin,
+    fraction,
+    keep_land_constant=False,
+    target_category=None,
+    target_distribution=None,
+    category_dim=None,
+):
+    """Convert land from one category to another.
+
+    Given a Land Data Array map with pixel values for the different land use
+    types, the model computes the new land use map after conversion of a
+    fraction of the per-pixel utilisation from a set of categories to a target
+    category.
+
+    Parameters
+    ----------
+    land : xarray.Dataarray
+        Input land array containing the id id value with the dominant land use
+        type on that pixel.
+    origin : str, array
+        Land category identifiers for the land uses to be converted.
+    fraction : float, xarray.DataArray
+        Conversion fraction of each repurposed land category. Can be a single
+        scalar value, an array with the same length as the origin land
+        categories, and optionally, include a time dimension for dynamic
+        conversion.
+    keep_land_constant : bool, optional
+        If True, the total land area is kept constant by scaling the other
+        categories proportionally to the change in the target category. If
+        False, only the target category is scaled, allowing the total land area
+        to change.
+    target : str, optional
+        Land category identifiers for the land use to convert to. If not
+        provided, the converted land distributed across all non-origin
+        categories.
+    target_distribution : array-like, xarray.DataArray, optional
+        Relative distribution used to allocate converted land across target
+        categories. If array-like, it must have the same length as ``target``.
+        If a DataArray, it must include ``category_dim`` with coordinates equal
+        to ``target`` and can optionally include a ``Year`` dimension for
+        time-varying distribution.    
+    category_dim : str
+        Name of the land category dimension in the input land DataArray.
+
+    Returns
+    -------
+    new_land : xarray.DataArray
+        DataArray with the new land use map after conversion.
+    """
+
+    if isinstance(origin, str):
+        origin = [origin]
+
+
+    # Use the first non spatial dimension if category dimension not provided
+    if category_dim is None:
+        category_dim = [d for d in land.dims if d not in ["Year", "x", "y"]][0]
+
+    for orig in origin:
+        if orig not in land[category_dim].values:
+            raise ValueError(f"Origin category {orig} not found in land"
+                             " categories")
+
+    new_land = land.copy()
+
+    # Validate fraction values
+    if np.isscalar(fraction):
+        if fraction < 0 or fraction > 1:
+            warnings.warn("Fraction values must be between 0 and 1")
+    else:
+        if np.any((fraction < 0) | (fraction > 1)):
+            warnings.warn("Fraction values must be between 0 and 1")
+
+    # Scale land
+    delta_land = land.sel({category_dim: origin}) * fraction
+
+    new_land.loc[{category_dim: origin}] -= delta_land
+
+    # If keeping land constant, distribute the converted land across targets
+    if keep_land_constant:
+        if target_category is None:
+            target_category = [c for c in land[category_dim].values if c not in origin]
+
+        elif isinstance(target_category, str):
+            target_category = [target_category]            
+
+        # Check that target class exist. If not, add them to the land categories
+        for targ in target_category:
+            if targ not in land[category_dim].values:
+                new_land = new_land.land.add_category(targ, category_dim=category_dim)
+
+        # Validate and normalize target distribution
+        if target_distribution is None:
+            target_distribution = np.ones(len(target_category), dtype=float)
+
+        if isinstance(target_distribution, xr.DataArray):
+            if category_dim not in target_distribution.dims:
+                raise ValueError(
+                    "target_distribution DataArray must include the category "
+                    f"dimension '{category_dim}'"
+                )
+
+            extra_dims = set(target_distribution.dims) - {category_dim, "Year"}
+            if extra_dims:
+                raise ValueError(
+                    "target_distribution DataArray supports only category and "
+                    f"optional Year dimensions, got extra dimensions: {extra_dims}"
+                )
+
+            dist_categories = set(target_distribution[category_dim].values.tolist())
+            target_categories = set(target_category)
+            if dist_categories != target_categories:
+                raise ValueError(
+                    "target_distribution category coordinates must match target "
+                    f"categories exactly. Expected {target_category}, got "
+                    f"{list(target_distribution[category_dim].values)}"
+                )
+
+            target_distribution = target_distribution.sel({category_dim: target_category})
+
+            if ((target_distribution < 0) | (~np.isfinite(target_distribution))).any():
+                raise ValueError("target_distribution values must be finite and" \
+                " non-negative")
+
+            dist_sum = target_distribution.sum(dim=category_dim)
+            if (dist_sum <= 0).any():
+                raise ValueError(
+                    "target_distribution must have a strictly positive total "
+                    "across target categories"
+                )
+
+            target_distribution = target_distribution / dist_sum
+        else:
+            target_distribution = np.asarray(target_distribution, dtype=float)
+            if target_distribution.ndim != 1 or target_distribution.size != len(target_category):
+                raise ValueError(
+                    "target_distribution must be a 1D array with the same length "
+                    "as target"
+                )
+
+            if np.any((target_distribution < 0) | (~np.isfinite(target_distribution))):
+                raise ValueError("target_distribution values must be finite and" \
+                "non-negative")
+
+            dist_sum = target_distribution.sum()
+            if dist_sum <= 0:
+                raise ValueError(
+                    "target_distribution must have a strictly positive total "
+                    "across target categories"
+                )
+
+            target_distribution = xr.DataArray(
+                target_distribution / dist_sum,
+                dims=[category_dim],
+                coords={category_dim: target_category},
+            )
+
+        total_delta = delta_land.sum(dim=category_dim)
+        distributed_delta = total_delta * target_distribution
+
+        new_land.loc[{category_dim: target_category}] += distributed_delta.sel({category_dim: target_category})
+
+    return new_land
+
+
+@pipeline_node(["land", "fbs", "fbs_reference"])
+def land_scaling_from_food(
+    land,
+    fbs,
+    fbs_reference,
+    element,
+    category,
+    items=None,
+    category_dim=None,
+    keep_land_constant=False,
+    target_category=None,
+    target_distribution=None,
+):
+    """Scale land categories based on relative changes to food quantities.
+    
+    Given two food balance sheets, this model uses the relative change in
+    selected items quantities to scale land categories in a land data array.
+
+    Parameters
+    ----------
+    land : xarray.DataArray
+        Input land array containing the land categories to be scaled.
+    fbs : xarray.DataSet
+        Food balance sheet dataset containing the current food quantities.
+    fbs_reference : xarray.DataSet
+        Food balance sheet dataset containing the reference food quantities.
+    category : string, list
+        Name or list of names of the land use categories to be scaled.
+    items : string, list, tuple, optional
+        Item or list of items to be used for scaling. If not provided, all
+        items are used.
+    element : string, optional
+        Name of the fbs element to obtain the food quantities.
+    category_dim : string, optional
+        Name of the dimension along which the land use categories are defined.
+        If not provided, the first non spatial dimension is used.
+    keep_land_constant : bool, optional
+        If True, the total land area is kept constant by scaling the other
+        categories proportionally to the change in the target category. If False,
+        only the target category is scaled, allowing the total land area to change.
+    target_category : string, list, optional
+        Name of the land category to be used as padding when keep_land_constant
+        is True.
+    target_distribution : array-like, xarray.DataArray, optional
+        Relative distribution used to allocate land changes across target
+        categories when keep_land_constant is True.
+    """
+
+    # Obtain reference and current food quantities
+    if items is not None:
+        items = item_parser(fbs_reference, items)
+    else:
+        items = fbs_reference.Item.values
+
+    ref_quantities = fbs_reference[element].sel(Item=items).sum(dim="Item")
+    obs_quantities = fbs[element].sel(Item=items).sum(dim="Item")
+
+    # Compute scaling factor
+    scaling_factor = obs_quantities / ref_quantities
+
+    out_land = scale_land(
+        land,
+        origin=category,
+        fraction=1 - scaling_factor,
+        keep_land_constant=keep_land_constant,
+        target_category=target_category,
+        target_distribution=target_distribution,
+        category_dim=category_dim,
+    )
+        
+    return out_land
+    

--- a/agrifoodpy/land/model.py
+++ b/agrifoodpy/land/model.py
@@ -126,24 +126,26 @@ def scale_land(
         Land category identifiers for the land uses to be converted.
     fraction : float, xarray.DataArray
         Conversion fraction of each repurposed land category. Can be a single
-        scalar value, an array with the same length as the origin land
-        categories, and optionally, include a time dimension for dynamic
-        conversion.
+        scalar value, or an xarray DataArray with the same length as the
+        ``origin`` land categories, and optionally, include a time dimension
+        for dynamic conversion.
     keep_land_constant : bool, optional
         If True, the total land area is kept constant by scaling the other
         categories proportionally to the change in the target category. If
         False, only the target category is scaled, allowing the total land area
         to change.
-    target : str, optional
-        Land category identifiers for the land use to convert to. If not
-        provided, the converted land distributed across all non-origin
+    target_category : str, optional
+        If keep_land_constant is True, this defines the land category
+        identifiers to convert land to in order to keep land constant. If not
+        provided, the converted land is distributed across all non-origin
         categories.
     target_distribution : array-like, xarray.DataArray, optional
         Relative distribution used to allocate converted land across target
         categories. If array-like, it must have the same length as ``target``.
         If a DataArray, it must include ``category_dim`` with coordinates equal
-        to ``target`` and can optionally include a ``Year`` dimension for
-        time-varying distribution.    
+        to ``target_category`` and can optionally include a ``Year`` dimension
+        for time-varying distribution. If not provided, the converted land is
+        distributed equally across target categories.
     category_dim : str
         Name of the land category dimension in the input land DataArray.
 
@@ -170,14 +172,14 @@ def scale_land(
 
     # Validate fraction values
     if np.isscalar(fraction):
-        if fraction < 0 or fraction > 1:
-            warnings.warn("Fraction values must be between 0 and 1")
+        if fraction < 0:
+            warnings.warn("Fraction values must be equal to or greater than 0")
     else:
-        if np.any((fraction < 0) | (fraction > 1)):
-            warnings.warn("Fraction values must be between 0 and 1")
+        if np.any((fraction < 0)):
+            warnings.warn("Fraction values must be equal to or greater than 0")
 
     # Scale land
-    delta_land = land.sel({category_dim: origin}) * fraction
+    delta_land = land.sel({category_dim: origin}) * (1 - fraction)
 
     new_land.loc[{category_dim: origin}] -= delta_land
 
@@ -276,10 +278,10 @@ def land_scaling_from_food(
     element,
     category,
     items=None,
-    category_dim=None,
     keep_land_constant=False,
     target_category=None,
     target_distribution=None,
+    category_dim=None,
 ):
     """Scale land categories based on relative changes to food quantities.
     
@@ -294,16 +296,13 @@ def land_scaling_from_food(
         Food balance sheet dataset containing the current food quantities.
     fbs_reference : xarray.DataSet
         Food balance sheet dataset containing the reference food quantities.
+    element : string
+        Name of the fbs element to obtain the food quantities from.
     category : string, list
         Name or list of names of the land use categories to be scaled.
     items : string, list, tuple, optional
         Item or list of items to be used for scaling. If not provided, all
         items are used.
-    element : string, optional
-        Name of the fbs element to obtain the food quantities.
-    category_dim : string, optional
-        Name of the dimension along which the land use categories are defined.
-        If not provided, the first non spatial dimension is used.
     keep_land_constant : bool, optional
         If True, the total land area is kept constant by scaling the other
         categories proportionally to the change in the target category. If False,
@@ -314,6 +313,9 @@ def land_scaling_from_food(
     target_distribution : array-like, xarray.DataArray, optional
         Relative distribution used to allocate land changes across target
         categories when keep_land_constant is True.
+    category_dim : string, optional
+        Name of the dimension along which the land use categories are defined.
+        If not provided, the first non spatial dimension is used.
     """
 
     # Obtain reference and current food quantities
@@ -331,7 +333,7 @@ def land_scaling_from_food(
     out_land = scale_land(
         land,
         origin=category,
-        fraction=1 - scaling_factor,
+        fraction=scaling_factor,
         keep_land_constant=keep_land_constant,
         target_category=target_category,
         target_distribution=target_distribution,

--- a/agrifoodpy/land/tests/test_land.py
+++ b/agrifoodpy/land/tests/test_land.py
@@ -4,7 +4,7 @@ from agrifoodpy.land.land import LandDataArray
 import pytest
 import matplotlib.pyplot as plt
 
-def test_area_by_type():
+def test_area_by_category():
     
     data = np.tile((np.arange(3, dtype=float)), (4,1))
 
@@ -12,36 +12,36 @@ def test_area_by_type():
                     coords={"x": [0, 1, 2, 3], "y": [0, 1, 2]})
 
     land = LandDataArray(da)
-    # Test area by type without explicit values
-    expected_result_no_values = np.array([4,4,4])
-    result_no_values = land.area_by_type()
+    # Test area by category without explicit categories
+    expected_result_no_categories = np.array([4,4,4])
+    result_no_categories = land.area_by_category()
     
-    assert(np.array_equal(expected_result_no_values, result_no_values))
-    assert(list(result_no_values.coords) == ["land"])
+    assert(np.array_equal(expected_result_no_categories, result_no_categories))
+    assert(list(result_no_categories.coords) == ["land"])
 
-    # Test area by type with explicit values
-    expected_result_values = np.array([4,4])
-    result_values = land.area_by_type(values=[1,2])
+    # Test area by category with explicit categories
+    expected_result_categories = np.array([4,4])
+    result_categories = land.area_by_category(categories=[1,2])
     
-    assert(np.array_equal(expected_result_values, result_values))
-    assert(list(result_values.coords) == ["land"])
+    assert(np.array_equal(expected_result_categories, result_categories))
+    assert(list(result_categories.coords) == ["land"])
 
-    # Test area by type with explicit dimension name
+    # Test area by category with explicit dimension name
     dim_name = "area"
     expected_result_dims = np.array([4,4,4])
-    result_dims = land.area_by_type(dim=dim_name)
+    result_dims = land.area_by_category(dim=dim_name)
     
     assert(np.array_equal(expected_result_dims, result_dims))
     assert(list(result_dims.coords) == [dim_name])
 
-    # Test area by type with nan values
+    # Test area by category with nan categories
     da_nan = da.copy(deep=True)
     da_nan[-1, -1] = np.nan
     da_nan.name = "land_nan"
     land_nan = LandDataArray(da_nan)
 
     expected_result_nan = np.array([4,4,3])
-    result_nan = land_nan.area_by_type()
+    result_nan = land_nan.area_by_category()
 
     assert(np.array_equal(expected_result_nan, result_nan))
     assert(list(result_nan.coords) == ["land_nan"])
@@ -62,27 +62,27 @@ def test_area_overlap():
     land_left = LandDataArray(da_left)
     land_right = LandDataArray(da_right)
 
-    # Test area overlap without explicit values
+    # Test area overlap without explicit categories
 
-    expected_results_no_values = np.ones((3,4))
-    result_no_values = land_left.area_overlap(da_right)
+    expected_results_no_cats = np.ones((3,4))
+    result_no_cats = land_left.area_overlap(da_right)
 
-    assert(np.array_equal(expected_results_no_values, result_no_values))
-    assert(list(result_no_values.coords) == [name_left, name_right])
+    assert(np.array_equal(expected_results_no_cats, result_no_cats))
+    assert(list(result_no_cats.coords) == [name_left, name_right])
 
-    # Test area overlap with explicit values
-    input_values_left = [1,2]
-    input_values_right = [2,3]
+    # Test area overlap with explicit categories
+    input_cat_left = [1,2]
+    input_cat_right = [2,3]
 
-    expected_results_values = np.ones((2,2))
-    result_values = land_left.area_overlap(da_right,
-                                           values_left=input_values_left,
-                                           values_right=input_values_right)
+    expected_results_categories = np.ones((2,2))
+    result_cats = land_left.area_overlap(da_right,
+                                           categories_left=input_cat_left,
+                                           categories_right=input_cat_right)
     
-    assert(np.array_equal(expected_results_no_values, result_no_values))
-    assert(np.array_equal(result_no_values.coords, [name_left, name_right]))
-    assert(np.array_equal(result_values[name_left].values, input_values_left))
-    assert(np.array_equal(result_values[name_right].values, input_values_right))
+    assert(np.array_equal(expected_results_no_cats, result_no_cats))
+    assert(np.array_equal(result_no_cats.coords, [name_left, name_right]))
+    assert(np.array_equal(result_cats[name_left].values, input_cat_left))
+    assert(np.array_equal(result_cats[name_right].values, input_cat_right))
 
     # Test area overlap with explicit dimension names
 
@@ -137,17 +137,18 @@ def test_category_match():
     assert result_basic.name == name_left
 
     # Example with values on left map
-    result_values_left = land_left.category_match(da_right, values_left=1)
-    assert result_values_left.where(result_values_left==1).equals(da_left.where(da_left==1))
+    result_values_left = land_left.category_match(da_right, categories_left=1)
+    assert result_values_left.where(result_values_left==1).equals(
+        da_left.where(da_left==1))
     assert np.all(result_values_left.where(result_values_left!=1).isnull())
 
     # Example with values on right map
-    result_values_left = land_left.category_match(da_right, values_right=1)
+    result_values_left = land_left.category_match(da_right, categories_right=1)
     
     # Example with multiple values on both maps
     result_multivar = land_left.category_match(da_right,
-                                               values_left=[0,1],
-                                               values_right=[1,2])
+                                               categories_left=[0,1],
+                                               categories_right=[1,2])
 
     non_nan_values = result_multivar.where(~np.isnan(result_multivar),
                                            drop=True)
@@ -158,7 +159,7 @@ def test_category_match():
     assert result_multivar.name == name_left
 
     # Example with non-matching values
-    result_non_matching = land_left.category_match(da_right, values_left=4)
+    result_non_matching = land_left.category_match(da_right, categories_left=4)
     assert np.all(result_non_matching.isnull())
 
 def test_plot():
@@ -184,20 +185,166 @@ def test_dominant_class():
     land = LandDataArray(da)
 
     # Test dominant class without coord name
-    result_no_coord = land.dominant_class()
+    result_no_coord = land.dominant_category()
     assert result_no_coord.equals(da.idxmax(dim="class"))
 
     # Test dominant class with coord name
-    result_coord = land.dominant_class(class_coord="class")
+    result_coord = land.dominant_category(category_dim="class")
     assert result_coord.equals(da.idxmax(dim="class"))
 
     # Test dominant class with non-matching coord name
     with pytest.raises(KeyError):
-        result_non_matching = land.dominant_class(class_coord="non_matching")
+        result_non_matching = land.dominant_category(category_dim="non_matching")
 
     # Test with return index set to True
-    result_return_index = land.dominant_class(return_index=True)
+    result_return_index = land.dominant_category(return_index=True)
     result_return_index_truth = xr.DataArray(np.argmax(data, axis=2),
                                              coords=coords_index)
 
     assert result_return_index.equals(result_return_index_truth)
+
+def test_add_category_basic():
+    categories = ["a", "b"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+
+    result = land.add_category("c")
+    assert "c" in result["categories"].values
+    assert np.all(result.sel(categories="c") == 0)
+
+def test_add_category_with_value():
+    categories = ["a", "b"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+    category_value = 1
+
+    result = land.add_category("c", category_value=category_value)
+    assert "c" in result["categories"].values
+    assert np.all(result.sel(categories="c") == category_value)
+
+def test_add_category_with_array_value():
+    categories = ["a", "b"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+
+    value_array_data = np.random.rand(len(coords["x"]), len(coords["y"]))
+
+    value_array = xr.DataArray(
+        value_array_data,
+        dims=["x", "y"],
+        coords={"x": coords["x"], "y": coords["y"]},
+    )
+
+    result = land.add_category("c", category_value=value_array)
+    assert "c" in result["categories"].values
+    xr.testing.assert_allclose(
+        result.sel(categories="c").drop_vars("categories"),
+        value_array)
+
+def test_add_category_with_mask():
+    categories = ["a", "b"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+
+    mask_array = xr.DataArray(
+        np.array([[True, False], [False, True], [True, True]]),
+        dims=["x", "y"],
+        coords={"x": coords["x"], "y": coords["y"]},
+    )
+
+    ex_result = xr.ones_like(mask_array).where(mask_array)
+
+    result = land.add_category("c", category_value=1, mask=mask_array)
+    assert "c" in result["categories"].values
+    assert result.sel(categories="c").drop_vars("categories").equals(ex_result)
+
+def test_add_category_where_validation():
+    classes = ["a", "b"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "class": classes,
+    }
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(classes))
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+
+    # Valid x/y boolean mask should pass
+    valid_where = xr.DataArray(
+        np.array([[True, False], [False, True], [True, True]]),
+        dims=["x", "y"],
+        coords={"x": coords["x"], "y": coords["y"]},
+    )
+    result = land.add_category("c", category_value=1, mask=valid_where)
+    assert "c" in result["class"].values
+
+    # Missing spatial dimensions should fail
+    invalid_where_dims = xr.DataArray(
+        np.array([True, False]),
+        dims=["x"],
+        coords={"x": coords["x"][:2]})
+    
+    with pytest.raises(ValueError):
+        land.add_category("d", category_value=1, mask=invalid_where_dims)
+
+    # Misaligned x coordinate should fail
+    invalid_where_coords = xr.DataArray(
+        np.array([[True, False], [False, True], [True, True]]),
+        dims=["x", "y"],
+        coords={"x": [10, 11, 12], "y": coords["y"]},
+    )
+    with pytest.raises(ValueError):
+        land.add_category("e", category_value=1, mask=invalid_where_coords)
+
+def test_add_category_existing_categories_error():
+    categories = ["a", "b"]
+    coords = {
+        "x": [0, 1],
+        "y": [0, 1],
+        "class": categories,
+    }
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+
+    with pytest.raises(ValueError):
+        land.add_category(["b"], category_value=1)
+
+def test_add_category_duplicate_input_categories_error():
+    classes = ["a", "b"]
+    coords = {
+        "x": [0, 1],
+        "y": [0, 1],
+        "class": classes,
+    }
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(classes))
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+
+
+    with pytest.raises(ValueError):
+        land.add_category(["c", "c"], category_value=1)

--- a/agrifoodpy/land/tests/test_land.py
+++ b/agrifoodpy/land/tests/test_land.py
@@ -259,6 +259,36 @@ def test_add_category_with_array_value():
         result.sel(categories="c").drop_vars("categories"),
         value_array)
 
+def test_add_category_with_year_array_value():
+    categories = ["a", "b"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "Year": [2000, 2001],
+        "categories": categories,
+    }
+    data = np.random.rand(
+        len(coords["x"]),
+        len(coords["y"]),
+        len(coords["Year"]),
+        len(categories),
+    )
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+
+    value_array = xr.DataArray(
+        np.random.rand(len(coords["x"]), len(coords["y"]), len(coords["Year"])),
+        dims=["x", "y", "Year"],
+        coords={"x": coords["x"], "y": coords["y"], "Year": coords["Year"]},
+    )
+
+    result = land.add_category("c", category_value=value_array)
+    assert "c" in result["categories"].values
+    xr.testing.assert_allclose(
+        result.sel(categories="c").drop_vars("categories"),
+        value_array,
+    )
+
 def test_add_category_with_mask():
     categories = ["a", "b"]
     coords = {
@@ -281,6 +311,44 @@ def test_add_category_with_mask():
     result = land.add_category("c", category_value=1, mask=mask_array)
     assert "c" in result["categories"].values
     assert result.sel(categories="c").drop_vars("categories").equals(ex_result)
+
+def test_add_category_with_year_mask():
+    categories = ["a", "b"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "Year": [2000, 2001],
+        "categories": categories,
+    }
+    data = np.random.rand(
+        len(coords["x"]),
+        len(coords["y"]),
+        len(coords["Year"]),
+        len(categories),
+    )
+    da = xr.DataArray(data, coords=coords)
+    land = LandDataArray(da)
+
+    mask_array = xr.DataArray(
+        np.array(
+            [
+                [[True, False], [False, True]],
+                [[False, True], [True, False]],
+                [[True, True], [False, False]],
+            ]
+        ),
+        dims=["x", "y", "Year"],
+        coords={"x": coords["x"], "y": coords["y"], "Year": coords["Year"]},
+    )
+
+    ex_result = xr.ones_like(mask_array, dtype=float).where(mask_array)
+
+    result = land.add_category("c", category_value=1, mask=mask_array)
+    assert "c" in result["categories"].values
+    xr.testing.assert_allclose(
+        result.sel(categories="c").drop_vars("categories"),
+        ex_result,
+    )
 
 def test_add_category_where_validation():
     classes = ["a", "b"]

--- a/agrifoodpy/land/tests/test_land.py
+++ b/agrifoodpy/land/tests/test_land.py
@@ -79,8 +79,8 @@ def test_area_overlap():
                                            categories_left=input_cat_left,
                                            categories_right=input_cat_right)
     
-    assert(np.array_equal(expected_results_no_cats, result_no_cats))
-    assert(np.array_equal(result_no_cats.coords, [name_left, name_right]))
+    assert(np.array_equal(expected_results_categories, result_cats))
+    assert(np.array_equal(result_cats.coords, [name_left, name_right]))
     assert(np.array_equal(result_cats[name_left].values, input_cat_left))
     assert(np.array_equal(result_cats[name_right].values, input_cat_right))
 

--- a/agrifoodpy/land/tests/test_model.py
+++ b/agrifoodpy/land/tests/test_model.py
@@ -48,3 +48,563 @@ def test_land_sequestration():
                         coords={"Year":np.arange(11)})
 
     xr.testing.assert_allclose(result, truth)
+
+# -----------------------------
+# Tests for scale_land function
+# -----------------------------
+
+def test_scale_land_basic():
+    # basic test with one category and one fraction
+
+    from agrifoodpy.land.model import scale_land
+
+    categories = ["Pasture", "Arable"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    land = xr.DataArray(data, coords=coords)
+
+    fraction = np.random.rand()
+
+    result = scale_land(land, origin="Pasture", fraction=fraction)
+
+    truth = land.copy(deep=True)
+    truth.loc[{"categories": "Pasture"}] *= fraction
+
+    xr.testing.assert_allclose(result, truth)
+
+def test_scale_land_multiple_categories():
+    # test with multiple categories and one fraction
+
+    from agrifoodpy.land.model import scale_land
+
+    categories = ["Pasture", "Arable", "Forest"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+
+    fraction = np.random.rand()
+
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    land = xr.DataArray(data, coords=coords)
+
+    result = scale_land(land, origin=["Pasture", "Arable"], fraction=fraction)
+
+    truth = land.copy(deep=True)
+    truth.loc[{"categories": ["Pasture", "Arable"]}] *= fraction
+
+    xr.testing.assert_allclose(result, truth)
+
+def test_scale_land_multiple_categories_multiple_fractions():
+    # test with multiple categories and multiple fractions
+
+    from agrifoodpy.land.model import scale_land
+
+    categories = ["Pasture", "Arable", "Forest"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    land = xr.DataArray(data, coords=coords)
+
+    fraction = xr.DataArray(
+        np.random.rand(2),
+        coords={"categories": ["Pasture", "Arable"]})
+
+    result = scale_land(land, origin=["Pasture", "Arable"], fraction=fraction)
+
+    truth = land.copy(deep=True)
+    truth.loc[{"categories": "Pasture"}] *= fraction.loc[{"categories": "Pasture"}]
+    truth.loc[{"categories": "Arable"}] *= fraction.loc[{"categories": "Arable"}]
+
+    xr.testing.assert_allclose(result, truth)
+
+def test_scale_land_single_target_category():
+    # test with target category
+
+    from agrifoodpy.land.model import scale_land
+
+    categories = ["Pasture", "Arable", "Forest"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    land = xr.DataArray(data, coords=coords)
+
+    fraction = np.random.rand()
+
+    result = scale_land(
+        land,
+        origin="Pasture",
+        fraction=fraction,
+        keep_land_constant=True,
+        target_category="Forest")
+
+    truth = land.copy(deep=True)
+    truth.loc[{"categories": "Pasture"}] *= fraction
+    truth.loc[{"categories": "Forest"}] += \
+        land.loc[{"categories": "Pasture"}] * (1-fraction)
+
+    xr.testing.assert_allclose(result, truth)
+
+def test_scale_land_multiple_target_categories():
+    # Test with multiple target categories
+
+    from agrifoodpy.land.model import scale_land
+
+    categories = ["Pasture", "Arable", "Forest", "Urban"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    land = xr.DataArray(data, coords=coords)
+
+    fraction = np.random.rand()
+
+    result = scale_land(
+        land,
+        origin="Pasture",
+        fraction=fraction,
+        keep_land_constant=True,
+        target_category=["Forest", "Urban"])
+    
+    truth = land.copy(deep=True)
+    truth.loc[{"categories": "Pasture"}] *= fraction
+    truth.loc[{"categories": ["Forest", "Urban"]}] += \
+        land.loc[{"categories": "Pasture"}] * (1-fraction) / 2
+
+    xr.testing.assert_allclose(result, truth)
+
+def test_scale_land_multiple_target_categories_with_distribution():
+    # Test with multiple target categories and target distribution
+
+    from agrifoodpy.land.model import scale_land
+
+    categories = ["Pasture", "Arable", "Forest", "Urban"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+    }
+
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    land = xr.DataArray(data, coords=coords)
+
+    fraction = np.random.rand()
+    target_distr_arr = np.random.rand(2)
+    target_distr_arr /= target_distr_arr.sum()
+    target_distribution = xr.DataArray(
+        target_distr_arr,
+        coords={"categories": ["Forest", "Urban"]})
+
+    result = scale_land(
+        land,
+        origin="Pasture",
+        fraction=fraction,
+        keep_land_constant=True,
+        target_category=["Forest", "Urban"],
+        target_distribution=target_distribution)
+    
+    truth = land.copy(deep=True)
+    truth.loc[{"categories": "Pasture"}] *= fraction
+    truth.loc[{"categories": "Forest"}] += land.loc[{"categories": "Pasture"}] \
+        * (1-fraction) * target_distribution.loc[{"categories": "Forest"}]
+    truth.loc[{"categories": "Urban"}] += land.loc[{"categories": "Pasture"}] \
+        * (1-fraction) * target_distribution.loc[{"categories": "Urban"}]
+
+    xr.testing.assert_allclose(result, truth)
+
+def test_scale_land_time_dependent_scale():
+    # Test with time dependent scale factor
+
+    from agrifoodpy.land.model import scale_land
+
+    categories = ["Pasture", "Arable", "Forest"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "categories": categories,
+        "Year": [2000, 2010]
+    }
+
+    data = np.random.rand(
+        len(coords["x"]),
+        len(coords["y"]),
+        len(categories),
+        len(coords["Year"])
+        )
+    land = xr.DataArray(data, coords=coords)
+
+    fraction = xr.DataArray(
+        np.random.rand(len(coords["Year"])),
+        coords={"Year": coords["Year"]})
+
+    result = scale_land(
+        land,
+        origin="Pasture",
+        fraction=fraction,
+        keep_land_constant=True,
+        target_category=["Arable", "Forest"],
+        target_distribution=[0.75, 0.25])
+    
+    truth = land.copy(deep=True)
+    for t in coords["Year"]:
+        truth.loc[{"categories": "Pasture", "Year": t}] \
+            *= fraction.loc[{"Year": t}]
+        
+        truth.loc[{"categories": "Arable", "Year": t}] \
+            += land.loc[{"categories": "Pasture", "Year": t}] \
+            * (1-fraction.loc[{"Year": t}]) * 0.75
+        
+        truth.loc[{"categories": "Forest", "Year": t}] \
+            += land.loc[{"categories": "Pasture", "Year": t}] \
+            * (1-fraction.loc[{"Year": t}]) * 0.25
+
+    xr.testing.assert_allclose(result, truth)
+
+def test_scale_land_custom_category_dim():
+    # Test with custom category dimension
+
+    from agrifoodpy.land.model import scale_land
+
+    categories = ["Pasture", "Arable", "Forest"]
+    coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "land_category": categories,
+    }
+
+    data = np.random.rand(len(coords["x"]), len(coords["y"]), len(categories))
+    land = xr.DataArray(data, coords=coords)
+
+    fraction = np.random.rand()
+
+    result = scale_land(
+        land,
+        origin="Pasture",
+        fraction=fraction,
+        keep_land_constant=True,
+        target_category=["Arable", "Forest"],
+        target_distribution=[0.75, 0.25],
+        category_dim="land_category")
+    
+    truth = land.copy(deep=True)
+    truth.loc[{"land_category": "Pasture"}] \
+        *= fraction
+    
+    truth.loc[{"land_category": "Arable"}] \
+        += land.loc[{"land_category": "Pasture"}] * (1-fraction) * 0.75
+    
+    truth.loc[{"land_category": "Forest"}] \
+        += land.loc[{"land_category": "Pasture"}] * (1-fraction) * 0.25
+
+    xr.testing.assert_allclose(result, truth)
+
+# --------------------------------
+# Tests for land_scaling_from_food
+# --------------------------------
+
+def test_land_scaling_from_food_basic():
+    # Basic test with unchanged food balance sheet and one category
+
+    from agrifoodpy.land.model import land_scaling_from_food
+
+    items = ["Beef", "Apples"]
+    food_coords = {"Item": items}
+    food_data = np.random.rand(len(food_coords["Item"]))
+
+    fbs_obs = xr.Dataset(
+        data_vars={"production": (["Item"], food_data)},
+        coords=food_coords
+    )
+    
+    fbs_ref = fbs_obs.copy(deep=True)
+
+    categories = ["Pasture", "Arable", "Forest"]
+    land_coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "category": categories,
+    }
+
+    land_data = np.random.rand(
+        len(land_coords["x"]),
+        len(land_coords["y"]),
+        len(land_coords["category"]))
+
+    land = xr.DataArray(land_data, coords=land_coords)
+
+    result = land_scaling_from_food(
+        land,
+        fbs_obs,
+        fbs_ref,
+        element="production",
+        category="Pasture")
+    
+    xr.testing.assert_allclose(result, land)
+
+def test_land_scaling_from_food_basic_change():
+    # Basic test with changed food balance sheet and one category
+
+    from agrifoodpy.land.model import land_scaling_from_food
+
+    items = ["Beef", "Apples"]
+    food_coords = {"Item": items}
+    food_data = np.random.rand(len(food_coords["Item"]))
+
+    fbs_ref = xr.Dataset(
+        data_vars={"production": (["Item"], food_data)},
+        coords=food_coords
+    )
+    
+    fbs_obs = fbs_ref.copy(deep=True)
+    fbs_obs["production"] *= 2
+
+    categories = ["Pasture", "Arable", "Forest"]
+    land_coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "category": categories,
+    }
+
+    land_data = np.random.rand(
+        len(land_coords["x"]),
+        len(land_coords["y"]),
+        len(land_coords["category"]))
+
+    land = xr.DataArray(land_data, coords=land_coords)
+
+    result = land_scaling_from_food(
+        land,
+        fbs_obs,
+        fbs_ref,
+        element="production",
+        category="Pasture")
+        
+    truth = land.copy(deep=True)
+    truth.loc[{"category":"Pasture"}] *= 2
+    
+    xr.testing.assert_allclose(result, truth)
+
+def test_land_scaling_from_food_with_items():
+    # Test with specified items
+
+    from agrifoodpy.land.model import land_scaling_from_food
+
+    items = ["Beef", "Apples"]
+    food_coords = {"Item": items}
+    food_data = np.random.rand(len(food_coords["Item"]))
+
+    fbs_ref = xr.Dataset(
+        data_vars={"production": (["Item"], food_data)},
+        coords=food_coords
+    )
+    
+    fbs_obs = fbs_ref.copy(deep=True)
+    fbs_obs["production"].loc[{"Item":"Beef"}] *= 2
+
+    categories = ["Pasture", "Arable", "Forest"]
+    land_coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "category": categories,
+    }
+
+    land_data = np.random.rand(
+        len(land_coords["x"]),
+        len(land_coords["y"]),
+        len(land_coords["category"]))
+
+    land = xr.DataArray(land_data, coords=land_coords)
+
+    result = land_scaling_from_food(
+        land,
+        fbs_obs,
+        fbs_ref,
+        element="production",
+        category="Pasture",
+        items=["Beef"])
+    
+    truth = land.copy(deep=True)
+    truth.loc[{"category":"Pasture"}] *= 2
+    
+    xr.testing.assert_allclose(result, truth)
+
+
+def test_land_scaling_from_food_with_target_categories():
+    # Test with constant land and target categories
+
+    from agrifoodpy.land.model import land_scaling_from_food
+
+    items = ["Beef", "Apples"]
+    food_coords = {"Item": items}
+    food_data = np.random.rand(len(food_coords["Item"]))
+
+    fbs_ref = xr.Dataset(
+        data_vars={"production": (["Item"], food_data)},
+        coords=food_coords
+    )
+    
+    food_scale = np.random.rand() * 0.5 + 1
+    fbs_obs = fbs_ref.copy(deep=True)
+    fbs_obs["production"].loc[{"Item":"Beef"}] *= food_scale
+
+
+    categories = ["Pasture", "Arable", "Forest"]
+    land_coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "category": categories,
+    }
+
+    land_data = np.random.rand(
+        len(land_coords["x"]),
+        len(land_coords["y"]),
+        len(land_coords["category"]))
+
+    land = xr.DataArray(land_data, coords=land_coords)
+
+    result = land_scaling_from_food(
+        land,
+        fbs_obs,
+        fbs_ref,
+        element="production",
+        category="Pasture",
+        keep_land_constant=True,
+        target_category="Forest",
+        items=["Beef"])
+    
+    truth = land.copy(deep=True)
+    truth.loc[{"category":"Pasture"}] *= food_scale
+    truth.loc[{"category":"Forest"}] -= land.loc[{"category":"Pasture"}] \
+        * (food_scale - 1)
+    
+    xr.testing.assert_allclose(result, truth)
+
+
+def test_land_scaling_from_food_with_target_categories_and_distribution():
+    # Test with constant land, target categories and target distribution
+    
+    from agrifoodpy.land.model import land_scaling_from_food
+
+    items = ["Beef", "Apples"]
+    food_coords = {"Item": items}
+    food_data = np.random.rand(len(food_coords["Item"]))
+
+    fbs_ref = xr.Dataset(
+        data_vars={"production": (["Item"], food_data)},
+        coords=food_coords
+    )
+    
+    food_scale = np.random.rand() * 0.5 + 1
+    fbs_obs = fbs_ref.copy(deep=True)
+    fbs_obs["production"].loc[{"Item":"Beef"}] *= food_scale
+
+
+    categories = ["Pasture", "Arable", "Forest"]
+    land_coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "category": categories,
+    }
+
+    land_data = np.random.rand(
+        len(land_coords["x"]),
+        len(land_coords["y"]),
+        len(land_coords["category"]))
+
+    land = xr.DataArray(land_data, coords=land_coords)
+
+    result = land_scaling_from_food(
+        land,
+        fbs_obs,
+        fbs_ref,
+        element="production",
+        category="Pasture",
+        keep_land_constant=True,
+        target_category=["Forest", "Arable"],
+        target_distribution=[0.75, 0.25],
+        items=["Beef"])
+    
+    truth = land.copy(deep=True)
+    truth.loc[{"category":"Pasture"}] *= food_scale
+    truth.loc[{"category":"Forest"}] -= land.loc[{"category":"Pasture"}] \
+        * (food_scale - 1) * 0.75
+    truth.loc[{"category":"Arable"}] -= land.loc[{"category":"Pasture"}] \
+        * (food_scale - 1) * 0.25
+    
+    xr.testing.assert_allclose(result, truth)
+
+def test_land_scaling_from_food_with_time_dependent_fbs():
+
+    from agrifoodpy.land.model import land_scaling_from_food
+
+    items = ["Beef", "Apples"]
+    years = [2000, 2010]
+    food_coords = {"Item": items, "Year": years}
+    food_data = np.random.rand(
+        len(food_coords["Item"]),
+        len(food_coords["Year"])
+        )
+
+    fbs_ref = xr.Dataset(
+        data_vars={"production": (["Item", "Year"], food_data)},
+        coords=food_coords
+    )
+    
+    food_scale = xr.DataArray(
+            np.random.rand(len(years)),
+            coords={"Year": years}
+        ) * 0.5 + 1
+    
+    fbs_obs = fbs_ref.copy(deep=True)
+    fbs_obs["production"].loc[{"Item":"Beef"}] *= food_scale
+
+    categories = ["Pasture", "Arable", "Forest"]
+    land_coords = {
+        "x": [0, 1, 2],
+        "y": [0, 1],
+        "category": categories,
+        "Year": years
+    }
+
+    land_data = np.random.rand(
+        len(land_coords["x"]),
+        len(land_coords["y"]),
+        len(land_coords["category"]),
+        len(land_coords["Year"])
+        )
+
+    land = xr.DataArray(land_data, coords=land_coords)
+
+    result = land_scaling_from_food(
+        land,
+        fbs_obs,
+        fbs_ref,
+        element="production",
+        category="Pasture",
+        keep_land_constant=True,
+        target_category="Forest",
+        items=["Beef"])
+    
+    truth = land.copy(deep=True)
+    truth.loc[{"category":"Pasture"}] *= food_scale
+    truth.loc[{"category":"Forest"}] -= land.loc[{"category":"Pasture"}] \
+        * (food_scale - 1)
+    
+    xr.testing.assert_allclose(result, truth)


### PR DESCRIPTION
## Description
This PR introduces new model functions and `LandDataArray` accessor functions to facilitate models where land is converted between different categories.

- `scale_land` is a basic multitool to scale and shift land quantities between existing a new categories. It optionally allows total land to be conserved by scaling selected target categories. 
- `land_scaling_from_food` performs land scaling based on the relative shifts between food quantities on selected Food Balance Sheet array elements and items. It uses `scale_land`. 
- `LandDataArray.add_category` is an accessor method which allows the addition of new categories to LandDataArray, optionally providing fill values in the form of scalars or spatial and/or temporal arrays.

It also standardises the terminology by referring to the different land uses as "categories", avoiding the use of "type" and "class" which can be confused with standard Python terminology. Several functions using old terminology have been assigned deprecation warning and will be removed in the future releases of the package. 

This PR fixes #91 and #92 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/FixOurFood/AgriFoodPy/blob/main/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
