### PR TITLE
Edited contributing guidelines, multiconstructor for yaml loader

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,8 @@ for each new feature simplifies the development, review and merge processes by
 maintining logical separation. To create a feature branch:
 
 ```bash
-  git fetch agrifoodpy
-  git checkout -b <your-branch-name> agrifoodpy/main
+  git fetch afp
+  git checkout -b <your-branch-name> afp/main
 ```
 
 ### Hack away!

--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -10,6 +10,7 @@ from inspect import signature
 import time
 import yaml
 import importlib
+import builtins
 from ..utils.dict_utils import get_dict, set_dict
 
 class Pipeline():
@@ -46,6 +47,23 @@ class Pipeline():
         pipeline : Pipeline
             The pipeline object.
         """
+
+        def dynamic_call_constructor(loader, suffix, node):
+            """Multi-constructor for arbitrary functions"""
+            func = cls._load_function(suffix)
+            
+            if isinstance(node, yaml.ScalarNode):
+                return func
+            elif isinstance(node, yaml.SequenceNode):
+                args = loader.construct_sequence(node)
+                return func(*args)
+            elif isinstance(node, yaml.MappingNode):
+                kwargs = loader.construct_mapping(node)
+                return func(**kwargs)
+            
+        # Register the multi-constructor for all tags starting with '!'
+        yaml.add_multi_constructor("!", dynamic_call_constructor,
+                                   Loader=yaml.FullLoader)
 
         with open(filename, "r") as f:
             config = yaml.load(f, Loader=yaml.FullLoader)

--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -10,7 +10,6 @@ from inspect import signature
 import time
 import yaml
 import importlib
-import builtins
 from ..utils.dict_utils import get_dict, set_dict
 
 class Pipeline():
@@ -33,6 +32,20 @@ class Pipeline():
         module = importlib.import_module(module_path)
         return getattr(module, func_name)
 
+    @staticmethod
+    def _is_supported_yaml_function(path):
+        """Return True for dotted numpy/xarray function paths."""
+        if not isinstance(path, str) or "." not in path:
+            return False
+
+        module_path, _ = path.rsplit(".", 1)
+        return (
+            module_path == "numpy"
+            or module_path.startswith("numpy.")
+            or module_path == "xarray"
+            or module_path.startswith("xarray.")
+        )
+
     @classmethod
     def read(cls, filename):
         """Read a pipeline configuration from a YAML file
@@ -48,22 +61,51 @@ class Pipeline():
             The pipeline object.
         """
 
-        def dynamic_call_constructor(loader, suffix, node):
-            """Multi-constructor for arbitrary functions"""
-            func = cls._load_function(suffix)
-            
-            if isinstance(node, yaml.ScalarNode):
-                return func
-            elif isinstance(node, yaml.SequenceNode):
-                args = loader.construct_sequence(node)
-                return func(*args)
-            elif isinstance(node, yaml.MappingNode):
-                kwargs = loader.construct_mapping(node)
-                return func(**kwargs)
-            
-        # Register the multi-constructor for all tags starting with '!'
-        yaml.add_multi_constructor("!", dynamic_call_constructor,
-                                   Loader=yaml.FullLoader)
+        def dynamic_call_constructor(package_name):
+            """Build a multi-constructor for supported package functions."""
+
+            def constructor(loader, suffix, node):
+                func_path = f"{package_name}.{suffix}" if suffix else package_name
+
+                # Check if the function path is supported
+                if not cls._is_supported_yaml_function(func_path):
+                    raise yaml.constructor.ConstructorError(
+                        None,
+                        None,
+                        f"Unsupported YAML function tag '!{func_path}'.",
+                        node.start_mark,
+                    )
+
+                func = cls._load_function(func_path)
+
+                if isinstance(node, yaml.ScalarNode):
+                    return func
+                if isinstance(node, yaml.SequenceNode):
+                    args = loader.construct_sequence(node)
+                    return func(*args)
+                if isinstance(node, yaml.MappingNode):
+                    kwargs = loader.construct_mapping(node)
+                    return func(**kwargs)
+
+                raise yaml.constructor.ConstructorError(
+                    None,
+                    None,
+                    f"Unsupported YAML node type for '!{func_path}'.",
+                    node.start_mark,
+                )
+
+            return constructor
+
+        yaml.add_multi_constructor(
+            "!numpy.",
+            dynamic_call_constructor("numpy"),
+            Loader=yaml.FullLoader,
+        )
+        yaml.add_multi_constructor(
+            "!xarray.",
+            dynamic_call_constructor("xarray"),
+            Loader=yaml.FullLoader,
+        )
 
         with open(filename, "r") as f:
             config = yaml.load(f, Loader=yaml.FullLoader)

--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -81,10 +81,10 @@ class Pipeline():
                 if isinstance(node, yaml.ScalarNode):
                     return func
                 if isinstance(node, yaml.SequenceNode):
-                    args = loader.construct_sequence(node)
+                    args = loader.construct_sequence(node, deep=True)
                     return func(*args)
                 if isinstance(node, yaml.MappingNode):
-                    kwargs = loader.construct_mapping(node)
+                    kwargs = loader.construct_mapping(node, deep=True)
                     return func(**kwargs)
 
                 raise yaml.constructor.ConstructorError(

--- a/agrifoodpy/pipeline/tests/data/test_config_numpy_array.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_numpy_array.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Numpy Array
+    params:
+      key: "test_numpy_array"
+      value: !numpy.array [[1, 2, 3]]

--- a/agrifoodpy/pipeline/tests/data/test_config_numpy_array_kwargs.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_numpy_array_kwargs.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Numpy Array
+    params:
+      key: "test_numpy_array"
+      value: !numpy.array {object: [1, 2, 3]}

--- a/agrifoodpy/pipeline/tests/data/test_config_unsupported_function.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_unsupported_function.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Unsupported Function
+    params:
+      key: "test_pandas_array"
+      value: !pandas.DataFrame {data: [1, 2, 3], columns: ["A", "B", "C"]}

--- a/agrifoodpy/pipeline/tests/data/test_config_xarray_dataarray.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_xarray_dataarray.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Xarray DataArray
+    params:
+      key: "test_value"
+      value: !xarray.DataArray [[1,2,3] , {Year: [2020, 2021, 2022]}, "Year"]

--- a/agrifoodpy/pipeline/tests/data/test_config_xarray_dataarray_kwargs.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_xarray_dataarray_kwargs.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Xarray DataArray
+    params:
+      key: "test_value"
+      value: !xarray.DataArray {data: [1, 2, 3], dims: ["Year"], coords: {Year: [2020, 2021, 2022]}}

--- a/agrifoodpy/pipeline/tests/test_pipeline.py
+++ b/agrifoodpy/pipeline/tests/test_pipeline.py
@@ -365,53 +365,53 @@ def test_pipeline_node_decorator():
 
 
 # Test reading YAML config with numpy array parameters and values
-def test_read_yaml_numpy_array_():
-        
-        script_dir = os.path.dirname(__file__)
-        config_path = os.path.join(script_dir, "data/test_config_numpy_array.yaml")
+def test_read_yaml_numpy_array():
+    
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_numpy_array.yaml")
 
-        pipeline = Pipeline.read(str(config_path))
-        pipeline.run()
+    pipeline = Pipeline.read(str(config_path))
+    pipeline.run()
 
-        assert np.array_equal(pipeline.params[0]['value'], np.array([1, 2, 3]))
-        assert np.array_equal(pipeline.datablock["test_numpy_array"], np.array([1, 2, 3]))
+    assert np.array_equal(pipeline.params[0]['value'], np.array([1, 2, 3]))
+    assert np.array_equal(pipeline.datablock["test_numpy_array"], np.array([1, 2, 3]))
 
 def test_read_yaml_numpy_array_kwargs():
-        script_dir = os.path.dirname(__file__)
-        config_path = os.path.join(script_dir, "data/test_config_numpy_array_kwargs.yaml")
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_numpy_array_kwargs.yaml")
 
-        pipeline = Pipeline.read(str(config_path))
-        pipeline.run()
+    pipeline = Pipeline.read(str(config_path))
+    pipeline.run()
 
-        assert np.array_equal(pipeline.params[0]['value'], np.array([1, 2, 3]))
-        assert np.array_equal(pipeline.datablock["test_numpy_array"], np.array([1, 2, 3]))
+    assert np.array_equal(pipeline.params[0]['value'], np.array([1, 2, 3]))
+    assert np.array_equal(pipeline.datablock["test_numpy_array"], np.array([1, 2, 3]))
 
 def test_read_yaml_xarray_dataarray():
-        script_dir = os.path.dirname(__file__)
-        config_path = os.path.join(script_dir, "data/test_config_xarray_dataarray.yaml")
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_xarray_dataarray.yaml")
 
-        pipeline = Pipeline.read(str(config_path))
-        pipeline.run()
+    pipeline = Pipeline.read(str(config_path))
+    pipeline.run()
 
-        expected_array = xr.DataArray([1, 2, 3], coords={"Year": [2020, 2021, 2022]}, dims=["Year"])
-        xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
-        xr.testing.assert_equal(pipeline.datablock["test_value"], expected_array)
+    expected_array = xr.DataArray([1, 2, 3], coords={"Year": [2020, 2021, 2022]}, dims=["Year"])
+    xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
+    xr.testing.assert_equal(pipeline.datablock["test_value"], expected_array)
 
 def test_read_yaml_xarray_dataarray_kwargs():
-        script_dir = os.path.dirname(__file__)
-        config_path = os.path.join(script_dir, "data/test_config_xarray_dataarray_kwargs.yaml")
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_xarray_dataarray_kwargs.yaml")
 
-        pipeline = Pipeline.read(str(config_path))
-        pipeline.run()
+    pipeline = Pipeline.read(str(config_path))
+    pipeline.run()
 
-        expected_array = xr.DataArray([1, 2, 3], coords={"Year": [2020, 2021, 2022]}, dims=["Year"])
-        xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
-        xr.testing.assert_equal(pipeline.datablock["test_value"], expected_array)
+    expected_array = xr.DataArray([1, 2, 3], coords={"Year": [2020, 2021, 2022]}, dims=["Year"])
+    xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
+    xr.testing.assert_equal(pipeline.datablock["test_value"], expected_array)
 
 def test_read_yaml_unsupported_function():
-        from yaml.constructor import ConstructorError
-        script_dir = os.path.dirname(__file__)
-        config_path = os.path.join(script_dir, "data/test_config_unsupported_function.yaml")
+    from yaml.constructor import ConstructorError
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_unsupported_function.yaml")
 
-        with pytest.raises(ConstructorError):
-            pipeline = Pipeline.read(str(config_path))
+    with pytest.raises(ConstructorError):
+        pipeline = Pipeline.read(str(config_path))

--- a/agrifoodpy/pipeline/tests/test_pipeline.py
+++ b/agrifoodpy/pipeline/tests/test_pipeline.py
@@ -1,5 +1,8 @@
 from agrifoodpy.pipeline import Pipeline, standalone
+import numpy as np
+import xarray as xr
 import pytest
+import os
 
 def test_init():
     pipeline = Pipeline()
@@ -359,3 +362,56 @@ def test_pipeline_node_decorator():
         @pipeline_node(['wrong_key'])
         def unknown_input_node(right_key):
             pass
+
+
+# Test reading YAML config with numpy array parameters and values
+def test_read_yaml_numpy_array_():
+        
+        script_dir = os.path.dirname(__file__)
+        config_path = os.path.join(script_dir, "data/test_config_numpy_array.yaml")
+
+        pipeline = Pipeline.read(str(config_path))
+        pipeline.run()
+
+        assert np.array_equal(pipeline.params[0]['value'], np.array([1, 2, 3]))
+        assert np.array_equal(pipeline.datablock["test_numpy_array"], np.array([1, 2, 3]))
+
+def test_read_yaml_numpy_array_kwargs():
+        script_dir = os.path.dirname(__file__)
+        config_path = os.path.join(script_dir, "data/test_config_numpy_array_kwargs.yaml")
+
+        pipeline = Pipeline.read(str(config_path))
+        pipeline.run()
+
+        assert np.array_equal(pipeline.params[0]['value'], np.array([1, 2, 3]))
+        assert np.array_equal(pipeline.datablock["test_numpy_array"], np.array([1, 2, 3]))
+
+def test_read_yaml_xarray_dataarray():
+        script_dir = os.path.dirname(__file__)
+        config_path = os.path.join(script_dir, "data/test_config_xarray_dataarray.yaml")
+
+        pipeline = Pipeline.read(str(config_path))
+        pipeline.run()
+
+        expected_array = xr.DataArray([1, 2, 3], coords={"Year": [2020, 2021, 2022]}, dims=["Year"])
+        xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
+        xr.testing.assert_equal(pipeline.datablock["test_value"], expected_array)
+
+def test_read_yaml_xarray_dataarray_kwargs():
+        script_dir = os.path.dirname(__file__)
+        config_path = os.path.join(script_dir, "data/test_config_xarray_dataarray_kwargs.yaml")
+
+        pipeline = Pipeline.read(str(config_path))
+        pipeline.run()
+
+        expected_array = xr.DataArray([1, 2, 3], coords={"Year": [2020, 2021, 2022]}, dims=["Year"])
+        xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
+        xr.testing.assert_equal(pipeline.datablock["test_value"], expected_array)
+
+def test_read_yaml_unsupported_function():
+        from yaml.constructor import ConstructorError
+        script_dir = os.path.dirname(__file__)
+        config_path = os.path.join(script_dir, "data/test_config_unsupported_function.yaml")
+
+        with pytest.raises(ConstructorError):
+            pipeline = Pipeline.read(str(config_path))

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -4,7 +4,7 @@ Command line tool
 =================
 
 The ``agrifoodpy`` command line tool allows you to run a pipeline of functions
-defined in a configuration file. This is useful for automating workflows and
+defined in a YAML configuration file. This is useful for automating workflows and
 reproducibility. You can specify the configuration file and an output file for
 the results.
 


### PR DESCRIPTION
## Description
This pull request adds new functionality to the configuration file loader by allowing arbitrary functions to be called to define objects passed as parameters to nodes.

It also fixes a typo in the contributing guidelines where the `afp` remote is defined but not used correctly to fetch changes from the main branch.

## Checklist
- [ ] Follow the [Contributor Guidelines](https://github.com/FixOurFood/AgriFoodPy/blob/main/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
