### PR TITLE
additional scalings and new parser constructor

### DIFF
--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -16,6 +16,18 @@ class Pipeline():
     '''Class for constructing and running pipelines of functions with
     individual sets of parameters.'''
 
+    _SCALE_YAML_FUNCTIONS = {
+        "linear": "agrifoodpy.utils.scaling.linear_scale",
+        "step": "agrifoodpy.utils.scaling.step_scale",
+        "pulse": "agrifoodpy.utils.scaling.pulse_scale",
+        "logistic": "agrifoodpy.utils.scaling.logistic_scale",
+        "smoothstep": "agrifoodpy.utils.scaling.smoothstep_scale",
+
+        "piecewise_linear": "agrifoodpy.utils.scaling.piecewise_linear_scale",
+        "piecewise_constant": "agrifoodpy.utils.scaling.piecewise_constant_scale",
+        "piecewise_smoothstep": "agrifoodpy.utils.scaling.piecewise_smoothstep_scale",
+    }
+
     def __init__(self, datablock=None):
         self.nodes = []
         self.params = []
@@ -34,9 +46,12 @@ class Pipeline():
 
     @staticmethod
     def _is_supported_yaml_function(path):
-        """Return True for dotted numpy/xarray function paths."""
+        """Return True for dotted numpy/xarray and scale function paths."""
         if not isinstance(path, str) or "." not in path:
             return False
+
+        if path in Pipeline._SCALE_YAML_FUNCTIONS.values():
+            return True
 
         module_path, _ = path.rsplit(".", 1)
         return (
@@ -45,6 +60,17 @@ class Pipeline():
             or module_path == "xarray"
             or module_path.startswith("xarray.")
         )
+
+    @staticmethod
+    def _resolve_yaml_function_path(namespace, suffix):
+        """Resolve YAML constructor suffixes to supported function paths."""
+        if namespace == "scale":
+            return Pipeline._SCALE_YAML_FUNCTIONS.get(suffix)
+
+        if suffix:
+            return f"{namespace}.{suffix}"
+
+        return namespace
 
     @classmethod
     def read(cls, filename):
@@ -65,14 +91,23 @@ class Pipeline():
             """Build a multi-constructor for supported package functions."""
 
             def constructor(loader, suffix, node):
-                func_path = f"{package_name}.{suffix}" if suffix else package_name
+                func_path = cls._resolve_yaml_function_path(package_name, suffix)
+                tag_path = f"{package_name}.{suffix}" if suffix else package_name
+
+                if func_path is None:
+                    raise yaml.constructor.ConstructorError(
+                        None,
+                        None,
+                        f"Unsupported YAML function tag '!{tag_path}'.",
+                        node.start_mark,
+                    )
 
                 # Check if the function path is supported
                 if not cls._is_supported_yaml_function(func_path):
                     raise yaml.constructor.ConstructorError(
                         None,
                         None,
-                        f"Unsupported YAML function tag '!{func_path}'.",
+                        f"Unsupported YAML function tag '!{tag_path}'.",
                         node.start_mark,
                     )
 
@@ -104,6 +139,11 @@ class Pipeline():
         yaml.add_multi_constructor(
             "!xarray.",
             dynamic_call_constructor("xarray"),
+            Loader=yaml.FullLoader,
+        )
+        yaml.add_multi_constructor(
+            "!scale.",
+            dynamic_call_constructor("scale"),
             Loader=yaml.FullLoader,
         )
 

--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -125,7 +125,7 @@ class Pipeline():
                 raise yaml.constructor.ConstructorError(
                     None,
                     None,
-                    f"Unsupported YAML node type for '!{func_path}'.",
+                    f"Unsupported YAML node type for '!{tag_path}'.",
                     node.start_mark,
                 )
 

--- a/agrifoodpy/pipeline/tests/data/test_config_scale_linear.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_scale_linear.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Scale Linear
+    params:
+      key: "test_scale_linear"
+      value: !scale.linear [2020, 2022, 2024, 2026, 1.0, 3.0]

--- a/agrifoodpy/pipeline/tests/data/test_config_scale_linear_kwargs.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_scale_linear_kwargs.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Scale Linear
+    params:
+      key: "test_scale_linear"
+      value: !scale.linear {y0: 2020, y1: 2022, y2: 2024, y3: 2026, c_init: 1.0, c_end: 3.0}

--- a/agrifoodpy/pipeline/tests/data/test_config_scale_logistic.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_scale_logistic.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Scale Logistic
+    params:
+      key: "test_scale_logistic"
+      value: !scale.logistic [2020, 2022, 2024, 2026, 1.0, 3.0]

--- a/agrifoodpy/pipeline/tests/data/test_config_scale_logistic_kwargs.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_scale_logistic_kwargs.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Scale Logistic
+    params:
+      key: "test_scale_logistic"
+      value: !scale.logistic {y0: 2020, y1: 2022, y2: 2024, y3: 2026, c_init: 1.0, c_end: 3.0}

--- a/agrifoodpy/pipeline/tests/data/test_config_scale_unsupported_function.yaml
+++ b/agrifoodpy/pipeline/tests/data/test_config_scale_unsupported_function.yaml
@@ -1,0 +1,6 @@
+nodes:
+  - function: agrifoodpy.utils.nodes.write_to_datablock
+    name: Scale Unsupported
+    params:
+      key: "test_scale_unsupported"
+      value: !scale.cubic [2020, 2022, 2024, 2026, 1.0, 3.0]

--- a/agrifoodpy/pipeline/tests/test_pipeline.py
+++ b/agrifoodpy/pipeline/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 from agrifoodpy.pipeline import Pipeline, standalone
+from agrifoodpy.utils.scaling import linear_scale, logistic_scale
 import numpy as np
 import xarray as xr
 import pytest
@@ -408,10 +409,62 @@ def test_read_yaml_xarray_dataarray_kwargs():
     xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
     xr.testing.assert_equal(pipeline.datablock["test_value"], expected_array)
 
+def test_read_yaml_scale_linear():
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_scale_linear.yaml")
+
+    pipeline = Pipeline.read(str(config_path))
+    pipeline.run()
+
+    expected_array = linear_scale(2020, 2022, 2024, 2026, 1.0, 3.0)
+    xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
+    xr.testing.assert_equal(pipeline.datablock["test_scale_linear"], expected_array)
+
+def test_read_yaml_scale_linear_kwargs():
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_scale_linear_kwargs.yaml")
+
+    pipeline = Pipeline.read(str(config_path))
+    pipeline.run()
+
+    expected_array = linear_scale(2020, 2022, 2024, 2026, 1.0, 3.0)
+    xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
+    xr.testing.assert_equal(pipeline.datablock["test_scale_linear"], expected_array)
+
+def test_read_yaml_scale_logistic():
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_scale_logistic.yaml")
+
+    pipeline = Pipeline.read(str(config_path))
+    pipeline.run()
+
+    expected_array = logistic_scale(2020, 2022, 2024, 2026, 1.0, 3.0)
+    xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
+    xr.testing.assert_equal(pipeline.datablock["test_scale_logistic"], expected_array)
+
+def test_read_yaml_scale_logistic_kwargs():
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_scale_logistic_kwargs.yaml")
+
+    pipeline = Pipeline.read(str(config_path))
+    pipeline.run()
+
+    expected_array = logistic_scale(2020, 2022, 2024, 2026, 1.0, 3.0)
+    xr.testing.assert_equal(pipeline.params[0]['value'], expected_array)
+    xr.testing.assert_equal(pipeline.datablock["test_scale_logistic"], expected_array)
+
 def test_read_yaml_unsupported_function():
     from yaml.constructor import ConstructorError
     script_dir = os.path.dirname(__file__)
     config_path = os.path.join(script_dir, "data/test_config_unsupported_function.yaml")
+
+    with pytest.raises(ConstructorError):
+        pipeline = Pipeline.read(str(config_path))
+
+def test_read_yaml_unsupported_scale_function():
+    from yaml.constructor import ConstructorError
+    script_dir = os.path.dirname(__file__)
+    config_path = os.path.join(script_dir, "data/test_config_scale_unsupported_function.yaml")
 
     with pytest.raises(ConstructorError):
         pipeline = Pipeline.read(str(config_path))

--- a/agrifoodpy/utils/scaling.py
+++ b/agrifoodpy/utils/scaling.py
@@ -4,9 +4,21 @@ import numpy as np
 import xarray as xr
 
 
+def _validate_non_decreasing_years(years):
+    """Validate that years are in non-decreasing order."""
+
+    if not all(earlier <= later for earlier, later in zip(years, years[1:])):
+        raise ValueError("Years must be in ascending order.")
+
+
 def logistic_scale(y0, y1, y2, y3, c_init, c_end):
     """
     Create an xarray DataArray with a logistic growth interval
+
+    The returned DataArray contains values that remain constant at c_init from
+    year y0 to y1, then transition following a logistic curve from c_init to
+    c_end between years y1 and y2, and finally remain constant at c_end from
+    year y2 to y3.
 
     Parameters:
         y0 : (int)
@@ -23,19 +35,22 @@ def logistic_scale(y0, y1, y2, y3, c_init, c_end):
             The final constant value.
 
     Returns: xarray DataArray
-        An xarray DataArray object with 'year' as the coordinate and values set
+        An xarray DataArray object with 'Year' as the coordinate and values set
         by a logistic growth between the user defined intervals.
     """
+
+    _validate_non_decreasing_years([y0, y1, y2, y3])
 
     # Create arrays and set values between y0 and y1 to c_init
     years = np.arange(y0, y3+1)
     values = np.ones_like(years, dtype=float) * c_init
 
     # Set values between y1 and y2 using a logistic curve
-    var_segment = np.logical_and(years >= y1, years < y2)
-    t = (years[var_segment] - y1) / (y2 - y1)
-    values[var_segment] = c_init \
-        + (c_end - c_init)*(1 / (1 + np.exp(-10 * (t - 0.5))))
+    if y1 < y2:
+        var_segment = np.logical_and(years >= y1, years < y2)
+        t = (years[var_segment] - y1) / (y2 - y1)
+        values[var_segment] = c_init \
+            + (c_end - c_init)*(1 / (1 + np.exp(-10 * (t - 0.5))))
 
     # Set values between y2 and y3 to c_end
     values[years >= y2] = c_end
@@ -46,12 +61,11 @@ def logistic_scale(y0, y1, y2, y3, c_init, c_end):
 
 def linear_scale(y0, y1, y2, y3, c_init, c_end):
     """
-    Create an xarray DataArray with a single coordinate called 'year'.
+    Create an xarray DataArray with a linear growth interval.
 
-    The values from the first year 'y0' up to a given year 'y1' will be
-    constant, then they will vary linearly between 'y1' and another given year
-    'y2', and from 'y2' until the end of the array 'y3', the values will
-    continue with a constant value.
+    The returned DataArray contains values that remain constant at c_init from
+    year y0 to y1, then transition linearly from c_init to c_end between years
+    y1 and y2, and finally remain constant at c_end from year y2 to y3.
 
     Parameters:
         y0 : (int)
@@ -67,25 +81,270 @@ def linear_scale(y0, y1, y2, y3, c_init, c_end):
         c_end : (float)
 
     Returns: xr.DataArray
-        An xarray DataArray object with 'year' as the coordinate and values set
+        An xarray DataArray object with 'Year' as the coordinate and values set
         by a linear growth between the user defined intervals.
     """
 
-    # Create arrays and set values between y0 and y1 to c_init
-    years = np.arange(y0, y3 + 1)
-    values = np.ones_like(years, dtype=float) * c_init
+    return piecewise_linear_scale(
+        years=[y0, y1, y2, y3],
+        values=[c_init, c_init, c_end, c_end]
+        )
 
-    # Set values between y1 and y2 using straight line.
-    var_segment = np.logical_and(years >= y1, years < y2)
-    if y2 == y1:
-        slope = c_end - c_init
-    else:
-        slope = float((c_end - c_init) / (y2 - y1))
-    values[var_segment] = slope * (years[var_segment] - y1) + c_init
+def piecewise_linear_scale(years, values):
+    """
+    Create an xarray DataArray with a piecewise linear scale.
 
-    # Set values between y2 and y3 to c_end
-    values[years >= y2] = c_end
+    The returned DataArray contains values that transition linearly between
+    specified years and values.
 
-    data_array = xr.DataArray(values, coords={'Year': years}, dims=['Year'])
+    Parameters:
+        years : (list of int)
+            A list of years where the values change.
+        values : (list of float)
+            A list of values corresponding to each year in the 'years' list.
+
+    Returns: xr.DataArray
+        An xarray DataArray object with 'Year' as the coordinate and values set
+        by a piecewise linear scale between the user defined intervals.
+    """
+
+    if len(years) != len(values):
+        raise ValueError("Length of 'years' and 'values' must be the same.")
+
+    _validate_non_decreasing_years(years)
+
+    # Create arrays for the full range of years
+    full_years = np.arange(years[0], years[-1] + 1)
+    full_values = np.zeros_like(full_years, dtype=float)
+
+    # Fill in the values for each segment
+    for i in range(len(years) - 1):
+        var_segment = np.logical_and(
+            full_years >= years[i],
+            full_years < years[i + 1]
+            )
+        
+        delta_years = years[i + 1] - years[i]
+        if delta_years == 0:
+            continue
+
+        slope = (values[i + 1] - values[i]) / delta_years
+
+        full_values[var_segment] = (slope
+                                    *(full_years[var_segment] - years[i])
+                                    +values[i])
+
+    # Set the value for the last year
+    full_values[full_years >= years[-1]] = values[-1]
+
+    data_array = xr.DataArray(
+        full_values,
+        coords={'Year': full_years},
+        dims=['Year']
+        )
 
     return data_array
+
+def piecewise_constant_scale(years, values):
+    """
+    Create an xarray DataArray with a piecewise constant scale.
+
+    The returned DataArray contains values that remain constant between
+    specified years and values.
+
+    Parameters:
+        years : (list of int)
+            A list of years where the values change.
+        values : (list of float)
+            A list of values corresponding to each year in the 'years' list.
+
+    Returns: xr.DataArray
+        An xarray DataArray object with 'Year' as the coordinate and values set
+        by a piecewise constant scale between the user defined intervals.
+    """
+
+    if len(years) != len(values):
+        raise ValueError("Length of 'years' and 'values' must be the same.")
+
+    _validate_non_decreasing_years(years)
+
+    # Create arrays for the full range of years
+    full_years = np.arange(years[0], years[-1] + 1)
+    full_values = np.zeros_like(full_years, dtype=float)
+
+    # Fill in the values for each segment
+    for i in range(len(years) - 1):
+        var_segment = np.logical_and(
+            full_years >= years[i],
+            full_years < years[i + 1]
+            )
+        
+        full_values[var_segment] = values[i]
+
+    # Set the value for the last year
+    full_values[full_years >= years[-1]] = values[-1]
+
+    data_array = xr.DataArray(
+        full_values,
+        coords={'Year': full_years},
+        dims=['Year']
+        )
+
+    return data_array
+
+def step_scale(y0, y1, y2, c_init, c_end):
+    """
+    Create an xarray DataArray with a step function.
+
+    The returned DataArray contains values that remain constant at c_init from
+    year y0 to y1, then transition immediately to c_end at year y1 and remain
+    constant at c_end thereafter.
+
+    Parameters:
+        y0 : (int)
+            Starting year.
+        y1 : (int)
+            Year where the step change occurs.
+        y2 : (int)
+            Last year in the array.
+        c_init : (float)
+            Value to use for initial constant scale segment.
+        c_end : (float)
+            Value to use for final constant scale segment.
+
+    Returns: xr.DataArray
+        An xarray DataArray object with 'Year' as the coordinate and values set
+        by a step change between the user defined intervals.
+    """
+
+    return piecewise_constant_scale(
+        years=[y0, y1, y2],
+        values=[c_init, c_end, c_end]
+        )
+
+def pulse_scale(y0, y1, y2, y3, c_init, c_pulse):
+    """
+    Create an xarray DataArray with a pulse function.
+
+    The returned DataArray contains values that remain constant at c_init from
+    year y0 to y1, then transition immediately to c_pulse at year y1 and remain
+    constant at c_pulse until year y2, after which it transitions back to
+    c_init and remains constant at c_init until year y3.
+
+    Parameters:
+        y0 : (int)
+            Starting year.
+        y1 : (int)
+            Year where the pulse starts.
+        y2 : (int)
+            Year where the pulse ends.
+        y3 : (int)
+            Last year in the array.
+        c_init : (float)
+            Value to use for initial and final constant scale segments.
+        c_pulse : (float)
+            Value to use for the pulse segment.
+
+    Returns: xr.DataArray
+        An xarray DataArray object with 'Year' as the coordinate and values set
+        by a pulse function between the user defined intervals.
+    """
+
+    return piecewise_constant_scale(
+        years=[y0, y1, y2, y3],
+        values=[c_init, c_pulse, c_init, c_init]
+        )
+
+
+def piecewise_smoothstep_scale(years, values, smoother=False):
+    """
+    Create an xarray DataArray with a piecewise smoothstep scale.
+
+    The returned DataArray contains values that transition smoothly between
+    specified years and values using a smoothstep function.
+
+    Parameters:
+        years : (list of int)
+            A list of years where the values change.
+        values : (list of float)
+            A list of values corresponding to each year in the 'years' list.
+
+    Returns: xr.DataArray
+        An xarray DataArray object with 'Year' as the coordinate and values set
+        by a piecewise smoothstep scale between the user defined intervals.
+    """
+
+    if len(years) != len(values):
+        raise ValueError("Length of 'years' and 'values' must be the same.")
+
+    _validate_non_decreasing_years(years)
+
+    # Create arrays for the full range of years
+    full_years = np.arange(years[0], years[-1] + 1)
+    full_values = np.zeros_like(full_years, dtype=float)
+
+    # Fill in the values for each segment
+    for i in range(len(years) - 1):
+        var_segment = np.logical_and(
+            full_years >= years[i],
+            full_years < years[i + 1]
+            )
+        
+        delta_years = years[i + 1] - years[i]
+        if delta_years == 0:
+            continue
+
+        t = (full_years[var_segment] - years[i]) / delta_years
+
+        if smoother:
+            # Use a smoother smoothstep function (5th degree polynomial)
+            smoothstep = t**3 * (t * (t * 6 - 15) + 10)
+        else:
+            smoothstep = t**2 * (3 - 2 * t)
+
+        full_values[var_segment] = (values[i]
+                                    + (values[i + 1] - values[i]) * smoothstep)
+
+    # Set the value for the last year
+    full_values[full_years >= years[-1]] = values[-1]
+
+    data_array = xr.DataArray(
+        full_values,
+        coords={'Year': full_years},
+        dims=['Year']
+        )
+
+    return data_array
+
+def smoothstep_scale(y0, y1, y2, y3, c_init, c_end, smoother=False):
+    """
+    Create an xarray DataArray with a smoothstep function.
+
+    The returned DataArray contains values that remain constant at c_init from
+    year y0 to y1, then transition smoothly to c_end between years y1 and y2,
+    and finally remain constant at c_end from year y2 to y3.
+
+    Parameters:
+        y0 : (int)
+            Starting year.
+        y1 : (int)
+            Year where the smooth transition starts.
+        y2 : (int)
+            Year where the smooth transition ends.
+        y3 : (int)
+            Last year in the array.
+        c_init : (float)
+            Value to use for initial constant scale segment.
+        c_end : (float)
+            Value to use for final constant scale segment.
+    
+    Returns: xr.DataArray
+        An xarray DataArray object with 'Year' as the coordinate and values set
+        by a smoothstep function between the user defined intervals.
+    """
+
+    return piecewise_smoothstep_scale(
+        years=[y0, y1, y2, y3],
+        values=[c_init, c_init, c_end, c_end],
+        smoother=smoother
+        )

--- a/agrifoodpy/utils/scaling.py
+++ b/agrifoodpy/utils/scaling.py
@@ -268,6 +268,9 @@ def piecewise_smoothstep_scale(years, values, smoother=False):
             A list of years where the values change.
         values : (list of float)
             A list of values corresponding to each year in the 'years' list.
+        smoother : (bool), optional
+            If True, use a smoother 5th-degree polynomial smoothstep;
+            otherwise use the standard smoothstep.
 
     Returns: xr.DataArray
         An xarray DataArray object with 'Year' as the coordinate and values set

--- a/agrifoodpy/utils/tests/test_scaling.py
+++ b/agrifoodpy/utils/tests/test_scaling.py
@@ -1,9 +1,21 @@
 import numpy as np
-from agrifoodpy.utils.scaling import linear_scale, logistic_scale
+import pytest
+from agrifoodpy.utils.scaling import (
+    linear_scale,
+    logistic_scale,
+    piecewise_constant_scale,
+    piecewise_linear_scale,
+    piecewise_smoothstep_scale,
+    pulse_scale,
+    smoothstep_scale,
+    step_scale,
+)
 
+# ---------------------------------
+# Tests for logistic_scale function
+# ---------------------------------
 
-def test_logistic_scale():
-
+def test_logistic_scale_basic():
     # Basic functionality test
     y0, y1, y2, y3 = 2000, 2005, 2010, 2015
     c_init, c_end = 0, 10
@@ -16,6 +28,7 @@ def test_logistic_scale():
     assert np.allclose(basic_result, truth)
     assert np.array_equal(basic_result["Year"].values, np.arange(2000, 2016))
 
+def test_logistic_scale_negative():
     # Negative values test
     y0, y1, y2, y3 = 2000, 2005, 2010, 2015
     c_init, c_end = -1, -10
@@ -26,14 +39,7 @@ def test_logistic_scale():
 
     assert np.allclose(negative_result, truth)
 
-    # Instant change test
-    y0, y1, y2, y3 = 2000, 2001, 2001, 2015
-    c_init, c_end = 0, 10
-    instant_change_result = logistic_scale(y0, y1, y2, y3, c_init, c_end)
-
-    assert instant_change_result[0] == 0
-    assert instant_change_result[1] == 10
-
+def test_logistic_scale_from_first_year():
     # Change from first year
     y0, y1, y2, y3 = 2000, 2000, 2000, 2015
     c_init, c_end = 0, 10
@@ -41,6 +47,7 @@ def test_logistic_scale():
 
     assert np.array_equal(change_first_year, c_end * np.ones(y3+1-y0))
 
+def test_logistic_scale_constant_value():
     # Constant value
     y0, y1, y2, y3 = 2000, 2000, 2000, 2015
     c_init, c_end = 5.5, 5.5
@@ -49,9 +56,24 @@ def test_logistic_scale():
     assert np.array_equal(constant_value, c_init * np.ones(y3+1-y0))
     assert np.array_equal(constant_value, c_end * np.ones(y3+1-y0))
 
+def test_logistic_scale_immediate_transition():
+    # y1 == y2 means no transition interval, so values jump to c_end at y1
+    result = logistic_scale(2000, 2005, 2005, 2010, 0, 10)
+    truth = [0, 0, 0, 0, 0, 10, 10, 10, 10, 10, 10]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2011))
+
+def test_logistic_scale_raises_for_decreasing_years():
+    with pytest.raises(ValueError, match="Years must be in ascending order"):
+        logistic_scale(2000, 2005, 2004, 2010, 0, 10)
+
+
+# -------------------------------
+# Tests for linear_scale function
+# -------------------------------
 
 def test_linear_scale():
-
     # Basic functionality test
     basic_result = linear_scale(2000, 2005, 2010, 2015, 0, 10)
     truth = [0, 0, 0, 0, 0, 0, 2, 4, 6, 8, 10, 10, 10, 10, 10, 10]
@@ -59,6 +81,7 @@ def test_linear_scale():
     assert np.allclose(basic_result, truth)
     assert np.array_equal(basic_result["Year"].values, np.arange(2000, 2016))
 
+def test_linear_scale_negative():
     # Negative values test
     y0, y1, y2, y3 = 2000, 2005, 2010, 2015
     c_init, c_end = -1, -10
@@ -68,14 +91,7 @@ def test_linear_scale():
 
     assert np.allclose(negative_result, truth)
 
-    # Instant change test
-    y0, y1, y2, y3 = 2000, 2001, 2001, 2015
-    c_init, c_end = 0, 10
-    instant_change_result = linear_scale(y0, y1, y2, y3, c_init, c_end)
-
-    assert instant_change_result[0] == 0
-    assert instant_change_result[1] == 10
-
+def test_linear_scale_from_first_year():
     # Change from first year
     y0, y1, y2, y3 = 2000, 2000, 2000, 2015
     c_init, c_end = 0, 10
@@ -83,6 +99,7 @@ def test_linear_scale():
 
     assert np.array_equal(change_first_year, c_end * np.ones(y3+1-y0))
 
+def test_linear_scale_constant_value():
     # Constant value
     y0, y1, y2, y3 = 2000, 2000, 2000, 2015
     c_init, c_end = 5.5, 5.5
@@ -90,3 +107,147 @@ def test_linear_scale():
 
     assert np.array_equal(constant_value, c_init * np.ones(y3+1-y0))
     assert np.array_equal(constant_value, c_end * np.ones(y3+1-y0))
+
+def test_linear_scale_start_immediately():
+    # y0 == y1 should start linear growth immediately at y0
+    result = linear_scale(2000, 2000, 2005, 2010, 0, 10)
+    truth = [0, 2, 4, 6, 8, 10, 10, 10, 10, 10, 10]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2011))
+
+def test_linear_scale_end_last_year():
+    # y2 == y3 should still return a valid series ending at c_end
+    result = linear_scale(2000, 2005, 2010, 2010, 0, 10)
+    truth = [0, 0, 0, 0, 0, 0, 2, 4, 6, 8, 10]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2011))
+
+def test_linear_scale_raises_for_decreasing_years():
+    with pytest.raises(ValueError, match="Years must be in ascending order"):
+        linear_scale(2000, 2005, 2004, 2010, 0, 10)
+
+
+# --------------------------------------
+# Tests for piecewise_linear_scale
+# --------------------------------------
+
+def test_piecewise_linear_scale_basic():
+    result = piecewise_linear_scale([2000, 2003, 2005], [0, 6, 10])
+    truth = [0, 2, 4, 6, 8, 10]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2006))
+
+
+def test_piecewise_linear_scale_raises_for_mismatched_lengths():
+    with pytest.raises(ValueError, match="Length of 'years' and 'values' must be the same"):
+        piecewise_linear_scale([2000, 2005], [0])
+
+
+def test_piecewise_linear_scale_raises_for_decreasing_years():
+    with pytest.raises(ValueError, match="Years must be in ascending order"):
+        piecewise_linear_scale([2000, 2005, 2004], [0, 1, 2])
+
+
+# --------------------------------------
+# Tests for piecewise_constant_scale
+# --------------------------------------
+
+def test_piecewise_constant_scale_basic():
+    result = piecewise_constant_scale([2000, 2003, 2005], [1, 3, 7])
+    truth = [1, 1, 1, 3, 3, 7]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2006))
+
+
+def test_piecewise_constant_scale_raises_for_mismatched_lengths():
+    with pytest.raises(ValueError, match="Length of 'years' and 'values' must be the same"):
+        piecewise_constant_scale([2000, 2005], [1])
+
+
+def test_piecewise_constant_scale_raises_for_decreasing_years():
+    with pytest.raises(ValueError, match="Years must be in ascending order"):
+        piecewise_constant_scale([2000, 2005, 2004], [1, 2, 3])
+
+
+# --------------------------------------
+# Tests for step_scale and pulse_scale
+# --------------------------------------
+
+def test_step_scale_basic():
+    result = step_scale(2000, 2003, 2005, 2, 9)
+    truth = [2, 2, 2, 9, 9, 9]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2006))
+
+
+def test_step_scale_immediate_transition():
+    result = step_scale(2000, 2000, 2003, 2, 9)
+    truth = [9, 9, 9, 9]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2004))
+
+
+def test_pulse_scale_basic():
+    result = pulse_scale(2000, 2002, 2004, 2006, 1, 5)
+    truth = [1, 1, 5, 5, 1, 1, 1]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2007))
+
+
+# --------------------------------------
+# Tests for piecewise_smoothstep_scale
+# and smoothstep_scale
+# --------------------------------------
+
+def test_piecewise_smoothstep_scale_basic():
+    result = piecewise_smoothstep_scale([2000, 2002], [0.0, 1.0])
+    truth = [0.0, 0.5, 1.0]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2003))
+
+
+def test_piecewise_smoothstep_scale_smoother_basic():
+    result = piecewise_smoothstep_scale([2000, 2002], [0.0, 1.0], smoother=True)
+    truth = [0.0, 0.5, 1.0]
+
+    assert np.allclose(result, truth)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2003))
+
+
+def test_piecewise_smoothstep_scale_raises_for_mismatched_lengths():
+    with pytest.raises(ValueError, match="Length of 'years' and 'values' must be the same"):
+        piecewise_smoothstep_scale([2000, 2005], [0.0])
+
+
+def test_piecewise_smoothstep_scale_raises_for_decreasing_years():
+    with pytest.raises(ValueError, match="Years must be in ascending order"):
+        piecewise_smoothstep_scale([2000, 2005, 2004], [0.0, 0.5, 1.0])
+
+
+def test_smoothstep_scale_wrapper_matches_piecewise():
+    result = smoothstep_scale(2000, 2002, 2004, 2006, 1.0, 3.0)
+    expected = piecewise_smoothstep_scale([2000, 2002, 2004, 2006], [1.0, 1.0, 3.0, 3.0])
+
+    assert np.allclose(result, expected)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2007))
+
+
+def test_smoothstep_scale_wrapper_matches_piecewise_smoother():
+    result = smoothstep_scale(2000, 2002, 2004, 2006, 1.0, 3.0, smoother=True)
+    expected = piecewise_smoothstep_scale(
+        [2000, 2002, 2004, 2006],
+        [1.0, 1.0, 3.0, 3.0],
+        smoother=True,
+    )
+
+    assert np.allclose(result, expected)
+    assert np.array_equal(result["Year"].values, np.arange(2000, 2007))
+

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -73,6 +73,7 @@ agrifoodpy:
 * ``!scale.pulse``
 * ``!scale.smoothstep``
 * ``!scale.piecewise_linear``
+* ``!scale.piecewise_constant``
 * ``!scale.piecewise_smoothstep``
 
 The ``!scale`` constructors call scaling utilities from

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -51,3 +51,52 @@ and ``function`` is the name of the function to be executed.
 The parameters are specified as a dictionary of key-value pairs,
 where the keys are the parameter names.
 
+YAML constructors
+-----------------
+
+Configuration files can also use YAML tags to construct values during parsing,
+which can be useful for creating complex objects without the need to read the
+pipeline in a python environment and create the objects there. 
+
+The agrifoodpy library provides access to arbitrary numpy and xarray functions
+through the following YAML constructors:
+
+* ``!numpy.<function>``
+* ``!xarray.<function>``
+
+Additionally, there are specific constructors for utility functions defined in
+agrifoodpy:
+
+* ``!scale.linear``
+* ``!scale.logistic``
+* ``!scale.step``
+* ``!scale.pulse``
+* ``!scale.smoothstep``
+* ``!scale.piecewise_linear``
+* ``!scale.piecewise_smoothstep``
+
+The ``!scale`` constructors call scaling utilities from
+``agrifoodpy.utils.scaling`` and return an ``xarray.DataArray``.
+
+Example with positional arguments:
+
+.. code-block:: yaml
+
+  nodes:
+    - function: agrifoodpy.utils.nodes.write_to_datablock
+      name: Linear scale
+      params:
+        key: my_scale
+        value: !scale.linear [2020, 2022, 2024, 2026, 1.0, 3.0]
+
+Example with keyword arguments:
+
+.. code-block:: yaml
+
+  nodes:
+    - function: agrifoodpy.utils.nodes.write_to_datablock
+      name: Logistic scale
+      params:
+        key: my_scale
+        value: !scale.logistic {y0: 2020, y1: 2022, y2: 2024, y3: 2026, c_init: 1.0, c_end: 3.0}
+


### PR DESCRIPTION
## Description
This pull request introduces new functions which can be used as temporal profiles for the different scaling models in `agrifoodpy`

It also registers these scaling functions with the custom `!scale` tag to be used in yaml configuration files.
e.g.
```yaml
nodes:
  - function: agrifoodpy.utils.nodes.write_to_datablock
    name: Write a linear profile to the datablock
    params:
      key: linear_scale
      value: !scale.linear_scale [2025, 2030, 2040, 2050, 1, 1.5]
```


## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/FixOurFood/AgriFoodPy/blob/main/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
