### PR TITLE
multiple return keys for tuple returning functions

### DIFF
--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -403,9 +403,10 @@ def pipeline_node(input_keys=None):
     be interpreted as datablock lookup keys. The corresponding objects will be
     extracted from the datablock and passed to the function. Unregistered
     keyword arguments will be passed directly to the function. The decorated
-    function takes a "return_key" kwarg to specify the key under which the
-    function output will be stored in the datablock. If not provided, the
-    function name will be used as the return key.
+    function takes "return_key" or "return_keys" kwargs to specify the keys
+    under which the function outputs will be stored in the datablock.
+    If not provided, the function name will be used as the prefix for the
+    return keys.
 
     Parameters
     ----------

--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -426,6 +426,51 @@ def pipeline_node(input_keys=None):
         input_keys = []
 
     def pipeline_decorator(func):
+
+        def normalize_return_keys(return_keys):
+            if isinstance(return_keys, (str, tuple)):
+                return [return_keys]
+
+            if isinstance(return_keys, list):
+                return return_keys
+
+            raise TypeError(
+                "return_key/return_keys must be a str, tuple, or list."
+            )
+
+        def validate_return_keys(return_keys):
+            if len(return_keys) == 0:
+                raise ValueError("return_keys cannot be empty.")
+
+            for i, key in enumerate(return_keys):
+                if isinstance(key, str):
+                    continue
+
+                if isinstance(key, tuple):
+                    if len(key) == 0:
+                        raise ValueError(
+                            f"return_keys[{i}] tuple path cannot be empty."
+                        )
+
+                    for j, key_part in enumerate(key):
+                        if not isinstance(key_part, str):
+                            raise TypeError(
+                                "return_keys[{}][{}] path component must be "
+                                "str, got {}.".format(
+                                    i,
+                                    j,
+                                    type(key_part).__name__,
+                                )
+                            )
+                    continue
+
+                raise TypeError(
+                    "return_keys[{}] must be str or tuple, got {}.".format(
+                        i,
+                        type(key).__name__,
+                    )
+                )
+
         reserved = {"datablock", "return_key", "return_keys"}
         if reserved & set(signature(func).parameters):
             raise ValueError(f"Function {func.__name__} has reserved parameter"
@@ -444,12 +489,29 @@ def pipeline_node(input_keys=None):
 
             # Pop wrapper-specific kwargs
             datablock = kwargs.pop("datablock", None)
-            
+
+            has_return_key = (
+                "return_key" in kwargs and kwargs["return_key"] is not None
+            )
+            has_return_keys = (
+                "return_keys" in kwargs and kwargs["return_keys"] is not None
+            )
+
+            if has_return_key and has_return_keys:
+                raise ValueError(
+                    "Ambiguous return mapping: both 'return_key' and "
+                    "'return_keys' were provided."
+                )
+
             return_keys = kwargs.pop("return_keys", None)
-            if return_keys is None:
-                return_keys = kwargs.pop("return_key", func.__name__)
-            if isinstance(return_keys, str):
-                return_keys = [return_keys]
+            return_key = kwargs.pop("return_key", None)
+
+            if return_keys is None and return_key is not None:
+                return_keys = return_key
+
+            if return_keys is not None:
+                return_keys = normalize_return_keys(return_keys)
+                validate_return_keys(return_keys)
 
             # Bind positional and keyword args to their parameter names
             func_sig = signature(func)
@@ -473,11 +535,33 @@ def pipeline_node(input_keys=None):
                                                         bound.arguments[key])
                 result = func(*bound.args, **bound.kwargs)
 
+                if return_keys is None:
+                    if isinstance(result, tuple):
+                        return_keys = [
+                            f"{func.__name__}_{i}" for i in range(len(result))
+                        ]
+                    else:
+                        return_keys = [func.__name__]
+
                 if isinstance(result, tuple):
+                    if len(return_keys) != len(result):
+                        raise ValueError(
+                            f"Function '{func.__name__}' returned tuple of "
+                            f"length {len(result)}, but {len(return_keys)} "
+                            "return keys were provided."
+                        )
+
                     for rk, rs in zip(return_keys, result):
                         set_dict(datablock, rk, rs)
 
                 else:
+                    if len(return_keys) != 1:
+                        raise ValueError(
+                            f"Function '{func.__name__}' returned non-tuple "
+                            f"{type(result).__name__}, but {len(return_keys)} "
+                            "return keys were provided."
+                        )
+
                     set_dict(datablock, return_keys[0], result)
 
                 return datablock

--- a/agrifoodpy/pipeline/pipeline.py
+++ b/agrifoodpy/pipeline/pipeline.py
@@ -426,7 +426,7 @@ def pipeline_node(input_keys=None):
         input_keys = []
 
     def pipeline_decorator(func):
-        reserved = {"datablock", "return_key"}
+        reserved = {"datablock", "return_key", "return_keys"}
         if reserved & set(signature(func).parameters):
             raise ValueError(f"Function {func.__name__} has reserved parameter"
                              f" names {reserved & set(signature(func).parameters)}."
@@ -444,7 +444,12 @@ def pipeline_node(input_keys=None):
 
             # Pop wrapper-specific kwargs
             datablock = kwargs.pop("datablock", None)
-            return_key = kwargs.pop("return_key", func.__name__)
+            
+            return_keys = kwargs.pop("return_keys", None)
+            if return_keys is None:
+                return_keys = kwargs.pop("return_key", func.__name__)
+            if isinstance(return_keys, str):
+                return_keys = [return_keys]
 
             # Bind positional and keyword args to their parameter names
             func_sig = signature(func)
@@ -468,8 +473,13 @@ def pipeline_node(input_keys=None):
                                                         bound.arguments[key])
                 result = func(*bound.args, **bound.kwargs)
 
-                set_dict(datablock, return_key, result)
-                
+                if isinstance(result, tuple):
+                    for rk, rs in zip(return_keys, result):
+                        set_dict(datablock, rk, rs)
+
+                else:
+                    set_dict(datablock, return_keys[0], result)
+
                 return datablock
         return wrapper
     return pipeline_decorator

--- a/agrifoodpy/pipeline/tests/test_pipeline.py
+++ b/agrifoodpy/pipeline/tests/test_pipeline.py
@@ -365,6 +365,119 @@ def test_pipeline_node_decorator():
             pass
 
 
+def test_pipeline_node_multi_output_and_return_keys():
+
+    from agrifoodpy.pipeline.pipeline import Pipeline, pipeline_node
+
+    @pipeline_node([])
+    def split_values():
+        return 10, 20
+
+    @pipeline_node([])
+    def scalar_value():
+        return 7
+
+    # Explicit string keys for tuple output
+    pipeline_string_keys = Pipeline()
+    pipeline_string_keys.add_node(
+        split_values,
+        params={"return_keys": ["out1", "out2"]},
+    )
+    pipeline_string_keys.run()
+    assert pipeline_string_keys.datablock["out1"] == 10
+    assert pipeline_string_keys.datablock["out2"] == 20
+
+    # Explicit tuple paths for tuple output
+    pipeline_tuple_paths = Pipeline()
+    pipeline_tuple_paths.add_node(
+        split_values,
+        params={"return_keys": [("nested", "a"), ("nested", "b")]},
+    )
+    pipeline_tuple_paths.run()
+    assert pipeline_tuple_paths.datablock["nested"]["a"] == 10
+    assert pipeline_tuple_paths.datablock["nested"]["b"] == 20
+
+    # Mixed str/tuple paths for tuple output
+    pipeline_mixed_paths = Pipeline()
+    pipeline_mixed_paths.add_node(
+        split_values,
+        params={"return_keys": ["out", ("nested", "out")]},
+    )
+    pipeline_mixed_paths.run()
+    assert pipeline_mixed_paths.datablock["out"] == 10
+    assert pipeline_mixed_paths.datablock["nested"]["out"] == 20
+
+    # Auto-generated keys for tuple outputs when no keys are passed
+    pipeline_auto_keys = Pipeline()
+    pipeline_auto_keys.add_node(split_values)
+    pipeline_auto_keys.run()
+    assert pipeline_auto_keys.datablock["split_values_0"] == 10
+    assert pipeline_auto_keys.datablock["split_values_1"] == 20
+
+    # Single tuple path through return_key for scalar output
+    pipeline_return_key_tuple = Pipeline()
+    pipeline_return_key_tuple.add_node(
+        scalar_value,
+        params={"return_key": ("nested", "scalar")},
+    )
+    pipeline_return_key_tuple.run()
+    assert pipeline_return_key_tuple.datablock["nested"]["scalar"] == 7
+
+    # Mismatch: tuple output with fewer keys
+    pipeline_tuple_mismatch = Pipeline()
+    pipeline_tuple_mismatch.add_node(
+        split_values,
+        params={"return_keys": ["only_one"]},
+    )
+    with pytest.raises(ValueError, match="returned tuple of length"):
+        pipeline_tuple_mismatch.run()
+
+    # Mismatch: scalar output with multiple keys
+    pipeline_scalar_mismatch = Pipeline()
+    pipeline_scalar_mismatch.add_node(
+        scalar_value,
+        params={"return_keys": ["a", "b"]},
+    )
+    with pytest.raises(ValueError, match="returned non-tuple"):
+        pipeline_scalar_mismatch.run()
+
+    # Empty return_keys is invalid
+    pipeline_empty_keys = Pipeline()
+    pipeline_empty_keys.add_node(
+        scalar_value,
+        params={"return_keys": []},
+    )
+    with pytest.raises(ValueError, match="cannot be empty"):
+        pipeline_empty_keys.run()
+
+    # Invalid key type is rejected
+    pipeline_bad_key_type = Pipeline()
+    pipeline_bad_key_type.add_node(
+        scalar_value,
+        params={"return_keys": [123]},
+    )
+    with pytest.raises(TypeError, match="must be str or tuple"):
+        pipeline_bad_key_type.run()
+
+    # Invalid tuple path component is rejected
+    pipeline_bad_tuple_component = Pipeline()
+    pipeline_bad_tuple_component.add_node(
+        scalar_value,
+        params={"return_keys": [("nested", 123)]},
+    )
+    with pytest.raises(TypeError, match="path component must be str"):
+        pipeline_bad_tuple_component.run()
+
+    # Providing both return_key and return_keys is ambiguous
+    pipeline_ambiguous_keys = Pipeline()
+    pipeline_ambiguous_keys.add_node(
+        scalar_value,
+        params={"return_key": "a", "return_keys": ["b"]},
+    )
+    with pytest.raises(ValueError, match="both 'return_key' and 'return_keys'"):
+        pipeline_ambiguous_keys.run()
+
+
 # Test reading YAML config with numpy array parameters and values
 def test_read_yaml_numpy_array():
     


### PR DESCRIPTION
## Description
This PR adjusts the behaviour of the `pipeline_node` decorator to allow functions returning multiple values to store their outputs in multiple keys of the datablock simultaneously

The decorator has two reserved keywords: `return_key` and `return_keys` which can only be used to identify the datablock path where results should be stored and cannot be used as part of the function signature.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/FixOurFood/AgriFoodPy/blob/main/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
